### PR TITLE
Readme update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,8 +61,7 @@ source code. AVDECC is a management layer, similar to SNMP MIB formats,
 which enables remote devices to detect, enumerate and configure AVB-related 
 devices based on their standardized management properties.
 
-+ https://github.com/jdkoftinoff/avdecc
-+ https://github.com/jdkoftinoff/avdecc-examples
++ https://github.com/jdkoftinoff/jdksavdecc-c
 
 XMOS
 ----


### PR DESCRIPTION
The Open-AVB Readme file was pointing to my older AVDECC github project which is now replaced with a new one with a different URL. This patch updates the README file to point to "jdksavdecc-c" 
