### PR TITLE
Fix Makefile to build with PTP support

### DIFF
--- a/kmod/igb/Makefile
+++ b/kmod/igb/Makefile
@@ -42,7 +42,7 @@ BUILD_KERNEL=$(shell uname -r)
 endif
 
 # Use IGB_PTP compile flag to enable IEEE-1588 PTP (documented in README)
-ifeq ($(filter %IGB_PTP,$(CFLAGS_EXTRA)),-DIGB_PTP)
+ifeq ($(filter %IGB_PTP,$(EXTRA_CFLAGS)),-DIGB_PTP)
   CFILES += igb_ptp.c
 endif
 


### PR DESCRIPTION
Hi Eric,

there's a typo in the Makefile, preventing the current driver to be built with PTP support.

The patch fixes this problem.

HTH
