### PR TITLE
examples: mrp_client: bugfix for mrpdhelper_notify_equal() comparison of...

### DIFF
--- a/examples/mrp_client/mrpdhelper.c
+++ b/examples/mrp_client/mrpdhelper.c
@@ -307,9 +307,9 @@ int mrpdhelper_notify_equal(struct mrpdhelper_notify *n1,
 			return 0;
 		break;
 	case mrpdhelper_attribtype_msrp_domain:
-		if ((n1->u.sd.id != n1->u.sd.id) ||
-		    (n1->u.sd.priority != n1->u.sd.priority) ||
-		    (n1->u.sd.vid != n1->u.sd.vid))
+		if ((n1->u.sd.id != n2->u.sd.id) ||
+		    (n1->u.sd.priority != n2->u.sd.priority) ||
+		    (n1->u.sd.vid != n2->u.sd.vid))
 			return 0;
 		break;
 	case mrpdhelper_attribtype_msrp_talker:


### PR DESCRIPTION
This is a bugfix for code that compares mrpd notification structures. It is independent of the core MRPD daemon code.
