### PR TITLE
Minor fixes of gptp flags

### DIFF
--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -106,12 +106,14 @@
 #define PTP_PDELAY_FOLLOWUP_REQ_CLOCK_ID(x) x+10
 #define PTP_PDELAY_FOLLOWUP_REQ_PORT_ID(x) x+18
 
-#define PTP_LI_61_BYTE 0
+#define PTP_LI_61_BYTE 1
 #define PTP_LI_61_BIT 0
-#define PTP_LI_59_BYTE 0
+#define PTP_LI_59_BYTE 1
 #define PTP_LI_59_BIT 1
 #define PTP_ASSIST_BYTE 0
 #define PTP_ASSIST_BIT 1
+#define PTP_PTPTIMESCALE_BYTE 1
+#define PTP_PTPTIMESCALE_BIT 3
 
 enum MessageType {
 	SYNC_MESSAGE = 0,

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -51,6 +51,7 @@ PTPMessageCommon::PTPMessageCommon(IEEE1588Port * port)
 	domainNumber = port->getClock()->getDomain();
 	// Set flags as necessary
 	memset(flags, 0, PTP_FLAGS_LENGTH);
+	flags[PTP_PTPTIMESCALE_BYTE] |= (0x1 << PTP_PTPTIMESCALE_BIT);
 	correctionField = 0;
 	_gc = false;
 	sourcePortIdentity = new PortIdentity();


### PR DESCRIPTION
- fixed byte of leap second flags
- added PTP timescale flag (according to table 10-6 "Reserved as TRUE, ignored on reception")
