### PR TITLE
MRP corrections

### DIFF
--- a/daemons/mrpd/mmrp.c
+++ b/daemons/mrpd/mmrp.c
@@ -217,7 +217,9 @@ int mmrp_event(int event, struct mmrp_attribute *rattrib)
 
 		mrp_lvatimer_fsm(&(MMRP_db->mrp_db), MRP_EVENT_LVATIMER);
 
+		MMRP_db->send_empty_LeaveAll_flag = 1;
 		mmrp_txpdu();
+		MMRP_db->send_empty_LeaveAll_flag = 0;
 		break;
 	case MRP_EVENT_RLA:
 		mrp_jointimer_start(&(MMRP_db->mrp_db));
@@ -943,7 +945,7 @@ mmrp_emit_svcvectors(unsigned char *msgbuf, unsigned char *msgbuf_eof,
 	 * If no attributes are declared, send a LeaveAll with an all 0
 	 * FirstValue, Number of Values set to 0 and not attribute event.
 	 */
-	if (0 == attrib_found_flag) {
+	if ((0 == attrib_found_flag) && MMRP_db->send_empty_LeaveAll_flag) {
 
 		mrpdu_vectorptr->VectorHeader = MRPDU_VECT_NUMVALUES(0) |
 						MRPDU_VECT_LVA(0xFFFF);

--- a/daemons/mrpd/mmrp.h
+++ b/daemons/mrpd/mmrp.h
@@ -65,6 +65,7 @@ struct mmrp_attribute {
 struct mmrp_database {
 	struct mrp_database mrp_db;
 	struct mmrp_attribute *attrib_list;
+	int send_empty_LeaveAll_flag;
 };
 
 int mmrp_init(int mmrp_enable);

--- a/daemons/mrpd/msrp.c
+++ b/daemons/mrpd/msrp.c
@@ -283,7 +283,9 @@ int msrp_event(int event, struct msrp_attribute *rattrib)
 
 		mrp_lvatimer_fsm(&(MSRP_db->mrp_db), MRP_EVENT_LVATIMER);
 
+		MSRP_db->send_empty_LeaveAll_flag = 1;
 		msrp_txpdu();
+		MSRP_db->send_empty_LeaveAll_flag = 0;
 		break;
 	case MRP_EVENT_RLA:
 		mrp_jointimer_start(&(MSRP_db->mrp_db));
@@ -1696,7 +1698,7 @@ msrp_emit_domainvectors(unsigned char *msgbuf, unsigned char *msgbuf_eof,
 	 * If no attributes are declared, send a LeaveAll with an all 0
 	 * FirstValue, Number of Values set to 0 and not attribute event.
 	 */
-	if (0 == attrib_found_flag) {
+	if ((0 == attrib_found_flag) && MSRP_db->send_empty_LeaveAll_flag) {
 
 		mrpdu_vectorptr->VectorHeader = MRPDU_VECT_NUMVALUES(0) |
 						MRPDU_VECT_LVA(0xFFFF);
@@ -2020,7 +2022,7 @@ msrp_emit_talkervectors(unsigned char *msgbuf, unsigned char *msgbuf_eof,
 	 * If no attributes are declared, send a LeaveAll with an all 0
 	 * FirstValue, Number of Values set to 0 and not attribute event.
 	 */
-	if (0 == attrib_found_flag) {
+	if ((0 == attrib_found_flag) && MSRP_db->send_empty_LeaveAll_flag) {
 
 		mrpdu_vectorptr->VectorHeader = MRPDU_VECT_NUMVALUES(0) |
 						MRPDU_VECT_LVA(0xFFFF);
@@ -2371,7 +2373,7 @@ msrp_emit_listenvectors(unsigned char *msgbuf, unsigned char *msgbuf_eof,
 	 * If no attributes are declared, send a LeaveAll with an all 0
 	 * FirstValue, Number of Values set to 0 and not attribute event.
 	 */
-	if (0 == attrib_found_flag) {
+	if ((0 == attrib_found_flag) && MSRP_db->send_empty_LeaveAll_flag) {
 
 		mrpdu_vectorptr->VectorHeader = MRPDU_VECT_NUMVALUES(0) |
 						MRPDU_VECT_LVA(0xFFFF);

--- a/daemons/mrpd/msrp.h
+++ b/daemons/mrpd/msrp.h
@@ -153,6 +153,7 @@ struct msrp_attribute {
 struct msrp_database {
 	struct mrp_database mrp_db;
 	struct msrp_attribute *attrib_list;
+	int send_empty_LeaveAll_flag;
 };
 
 int msrp_init(int msrp_enable);

--- a/daemons/mrpd/mvrp.c
+++ b/daemons/mrpd/mvrp.c
@@ -167,7 +167,9 @@ int mvrp_event(int event, struct mvrp_attribute *rattrib)
 
 		mrp_lvatimer_fsm(&(MVRP_db->mrp_db), MRP_EVENT_LVATIMER);
 
+		MVRP_db->send_empty_LeaveAll_flag = 1;
 		mvrp_txpdu();
+		MVRP_db->send_empty_LeaveAll_flag = 0;
 		break;
 	case MRP_EVENT_RLA:
 		mrp_jointimer_start(&(MVRP_db->mrp_db));
@@ -776,7 +778,7 @@ mvrp_emit_vidvectors(unsigned char *msgbuf, unsigned char *msgbuf_eof,
 	 * If no attributes are declared, send a LeaveAll with an all 0
 	 * FirstValue, Number of Values set to 0 and not attribute event.
 	 */
-	if (0 == attrib_found_flag) {
+	if ((0 == attrib_found_flag) && MVRP_db->send_empty_LeaveAll_flag) {
 
 		mrpdu_vectorptr->VectorHeader = MRPDU_VECT_NUMVALUES(0) |
 						MRPDU_VECT_LVA(0xFFFF);

--- a/daemons/mrpd/mvrp.h
+++ b/daemons/mrpd/mvrp.h
@@ -40,8 +40,9 @@ struct mvrp_attribute {
 };
 
 struct mvrp_database {
-	struct mrp_database mrp_db;
-	struct mvrp_attribute *attrib_list;
+        struct mrp_database mrp_db;
+        struct mvrp_attribute *attrib_list;
+        int send_empty_LeaveAll_flag;
 };
 
 #define MVRP_ETYPE	0x88F5


### PR DESCRIPTION
This commit causes mrpd to emit "empty" (all 0 FirstValue) vectors every LeaveAll if no vectors of a specific type are declared.
