### PR TITLE
Fixed 32 bit compile issue

### DIFF
--- a/lib/igb/igb.c
+++ b/lib/igb/igb.c
@@ -1097,13 +1097,14 @@ igb_clean(device_t *dev, struct igb_packet **cleaned_packets)
 #define MIN_SYSCLOCK_WINDOW 72 /* ns */
 
 static inline void rdtscpll( uint64_t *val ) {
+	uint32_t high, low;
 	__asm__ __volatile__( "lfence;"
 						  "rdtsc;"
-						  "shl $32,%%rdx;"
-						  "or %%rdx,%%rax"
-						  : "=a"(*val)
+						  : "=d"(high), "=a"(low)
 						  :
-						  : "%rdx", "memory" );
+						  : "memory" );
+	*val = high;
+	*val = (*val << 32) | low;
 }
 
 static inline void __sync() {


### PR DESCRIPTION
rdtscpll now compiles and runs on 32 and 64 bit systems
