### PR TITLE
mrp: mrp_lvatimer_fsm(), set tx flag when MRP_EVENT_LVATIMER occurs.

### DIFF
--- a/daemons/mrpd/mrp.c
+++ b/daemons/mrpd/mrp.c
@@ -370,6 +370,7 @@ int mrp_lvatimer_fsm(struct mrp_database *mrp_db, int event)
 		mrp_lvatimer_start(mrp_db);
 		break;
 	case MRP_EVENT_LVATIMER:
+		tx = 1;
 		la_state = MRP_TIMER_ACTIVE;
 		mrp_lvatimer_stop(mrp_db);
 		mrp_lvatimer_start(mrp_db);


### PR DESCRIPTION
This patch fixes a bug where pdus were being sent from LVATIMER event
without the LeaveAll flag being set.
