### PR TITLE
igb_get_wallclock clears registers

### DIFF
--- a/lib/igb/igb.c
+++ b/lib/igb/igb.c
@@ -954,7 +954,7 @@ static __inline__ u_int64_t rdtscpll(void)
 	u_int32_t lo, hi;
 
 	__asm__ __volatile__ ("cpuid");
-	__asm__ __volatile__ ("rdtsc" : "=a" (lo), "=d" (hi));
+	__asm__ __volatile__ ("rdtsc" : "=a" (lo), "=d" (hi): "a"(0) : "%ebx", "%ecx");
 	return (u_int64_t) hi << 32 | lo;
 }
 


### PR DESCRIPTION
You should explicitly overwrite %ebx and %ecx so the compiler saves them before calling the wallclock function.
Explanation is found here: http://stackoverflow.com/questions/4473452/making-mistake-in-inline-assembler-in-gcc
This was causing us some serious headaches with a counter variable falling back to 0 when calling igb_get_wallclock.
