### PR TITLE
daemons: maap: add support for MAAP protocol

### DIFF
--- a/daemons/maap/README.rst
+++ b/daemons/maap/README.rst
@@ -1,0 +1,67 @@
+Introduction
+------------
+
+Multicast MAC addresses or locally administered unicast addresses are required
+by AVTP for the transmission of media streams. Because AVTP runs directly on a
+layer 2 transport, there is no existing protocol to allocate multicast MAC
+addresses dynamically. MAAP is designed to provide a way to allocate dynamically
+the multicast MAC addresses needed by AVTP. MAAP is not designed to allocate locally
+administered unicast addresses.
+
+A block of Multicast MAC addresses has been reserved for the use of AVTP. These addresses are listed in
+MAAP Dynamic Allocation Pool below shown. These addresses are available for dynamic allocation by the MAAP.
+91:E0:F0:00:00:00 – 91:E0:F0:00:FD:FF
+
+
+Linux Specific
+++++++++++++++
+
+To build, execute the linux makefile.
+
+To execute(in root), go to build directory(where binary is created) and run
+	./maap_daemon <interface-name>
+such as
+	./maap_daemon eth0
+
+The daemon creates a 6 bytes shared memory segment with the key 1234 and writes the allocated mac-addr there.
+The client applications will have to use this key value 1234 in the applications and read the allocated mac-addr
+and use it as dest mac-addr for the packets transmission.
+
+
+Execute Command :
+------------
+
+	sudo ./maap_daemon eth0
+
+
+OUTPUT :
+------------
+
+$ sudo ./maap_daemon eth0
+
+SENT MAAP_PROBE 
+
+SENT MAAP_PROBE 
+
+SENT MAAP_PROBE 
+
+SENT MAAP_ANNOUNCE 
+
+ANNOUNCED ADDRESS:
+0x91 0xe0 0xf0 0 0x95 0x18 
+
+STATE change to DEFEND:
+   
+SENT MAAP_ANNOUNCE
+SENT MAAP_ANNOUNCE
+SENT MAAP_ANNOUNCE
+
+Here in the case the allocated address which starts from 0x91 0xe0 0xf0 0 0x95 0x18 
+This mac-addr is assigned to Dest-Mac for packets transfer.
+ADDR[0] = 0x91
+ADDR[1] = 0xe0
+ADDR[2] = 0xf0
+ADDR[3] = 0
+ADDR[4] = 0x95
+ADDR[5] = 0x18
+

--- a/daemons/maap/common/maap_protocol.c
+++ b/daemons/maap/common/maap_protocol.c
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2014 VAYAVYA LABS PVT LTD - http://vayavyalabs.com/
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU Lesser General Public License,
+ * version 2.1, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/* MAC Address Acquisition Protocol- dynamically allocate multicast MAC address */
+#include "maap_protocol.h"
+
+extern uint8_t *maap_shm_mem;
+
+/* generate pseudo random mac_address in the MAAP range */
+void generate_address(maap_info_t *maap_info)
+{
+	uint16_t val;
+	uint8_t maap_address_llimit[6] = {0x91,0xE0,0xF0,0x00,0x00,0x00};
+
+	memcpy(maap_info->requested_mac_add, maap_address_llimit, MAC_ADDR_LEN);
+	val = rand_range(0x0000, 0xFDFF);
+	maap_info->requested_mac_add[4] = (val & 0xff00) >> 8; 
+	maap_info->requested_mac_add[5] = val & 0x00ff;
+}
+
+int state_transit(maap_info_t *maap_info) 
+{  
+	state_t current_state = maap_info->state;
+	maap_pdu_t *maap_pdu = &maap_info->ethpkt.data;
+	ethpkt_t *pkt_tx = &maap_info->ethpkt; 
+	ethpkt_t *pkt_rx = &maap_info->ethpkt_rx;
+	msg_type_t msg_type = 0;
+	uint8_t *s = NULL;
+	int i= 0;
+	int num_bytes = 0;
+	int maap_probe_count;
+
+	switch (current_state) {
+	case INITIAL:
+		DBG("state: INITIAL\n");
+		generate_address(maap_info);
+		maap_probe_count = MAAP_PROBE_RETRANSMITS; 
+		maap_info->state = PROBE;
+		break;
+
+	case PROBE: 
+		DBG("state: PROBE\n");
+		prepare_ethpkt(maap_info, MAAP_PROBE);
+
+		while (maap_probe_count) {
+			/* send MAAP_PROBE */
+			send_packet(pkt_tx);
+			printf("\nSENT MAAP_PROBE \n");
+
+			delay(0, PROBE_TIMER_MS);
+
+			memset(pkt_rx, 0x00, ETH_PKT_LEN);
+			/* Listen for MAAP_DEFEND */
+			num_bytes = recv_packet(pkt_rx, NON_BLOCK);
+			if (num_bytes > 0) {
+				msg_type = pkt_rx->data.message_type; 
+				DBG("msg_type %x \n",msg_type);
+
+				if (msg_type == MAAP_DEFEND || 
+				msg_type ==  MAAP_ANNOUNCE ||
+				msg_type == MAAP_PROBE) {
+					if (compare_mac(pkt_rx->data.requested_start_address,
+					maap_pdu->requested_start_address)) {
+						DBG("\nReceived\
+						MAAP_DEFEND frame from \
+						Mac Address: ");
+						DBG_ADDR(pkt_rx->header.h_source);
+						DBG("\nRequested\
+						Address of recv frame: ");
+						DBG_ADDR(pkt_rx->data.requested_start_address);
+						DBG("\nRequested Address: ");
+						DBG_ADDR(maap_pdu->requested_start_address);
+
+						maap_info->state = INITIAL;
+						return 1;
+					}
+			} else {
+				printf("\n Invalid MAAP packet\n");
+			}  
+			} else {
+				maap_probe_count -=1;
+			}  
+		}
+
+		maap_info->acquired_mac_count =
+			maap_info->requested_mac_count;
+		memcpy(maap_info->acquired_mac_add,
+			maap_info->requested_mac_add, MAC_ADDR_LEN);
+
+		prepare_ethpkt(maap_info, MAAP_ANNOUNCE);
+		send_packet(pkt_tx);  
+
+		create_thread(maap_info, send_announce);
+
+		printf("\nSENT MAAP_ANNOUNCE \n\nANNOUNCED ADDRESS:\n");
+			DBG_ADDR(maap_info->acquired_mac_add);
+
+		s = maap_shm_mem;
+		/* writing allocated mac-address to shared memory */
+		for (i = 0; i < MAC_ADDR_LEN ; i++) {
+			*s++ = maap_info->acquired_mac_add[i];
+		}
+
+		maap_info->state = DEFEND;
+		printf("\n\nSTATE change to DEFEND:\n");
+		break;
+
+	case DEFEND:
+		memset(pkt_rx, 0x00, ETH_PKT_LEN);
+		/* Listen MAAP_PROBE */
+		num_bytes = recv_packet(pkt_rx, BLOCK);
+
+		if (num_bytes > 0) {
+			msg_type = pkt_rx->data.message_type;
+			if (compare_mac(pkt_rx->data.requested_start_address,
+				maap_info->acquired_mac_add)) {
+				if (msg_type == MAAP_PROBE) {
+					memcpy(maap_info->conflict_mac_add,
+					pkt_rx->data.requested_start_address,
+					MAC_ADDR_LEN);
+					maap_info->conflict_mac_count =
+					pkt_rx->data.requested_count;
+
+					DBG("\n Received frame\
+						MAAP_PROBE \n Source address of\
+						the received frame:"); 
+					DBG_ADDR(pkt_rx->header.h_source);
+					DBG("\n Requested start address\
+						of received frame :");
+					DBG_ADDR(pkt_rx->data.requested_start_address);
+					DBG("\n Announced Address :");
+					DBG_ADDR(maap_info->acquired_mac_add);
+
+					Lock();
+					prepare_ethpkt(maap_info,
+						MAAP_DEFEND);
+					send_packet(pkt_tx);
+					UnLock();
+					DBG(" SENT DEFEND \n"); 
+				} else if (msg_type == MAAP_ANNOUNCE ||
+					msg_type == MAAP_DEFEND) {
+					DBG("\n Received \
+					msg_type-MAAP_ANNOUNCE \
+					Source Address: ");
+					DBG_ADDR(pkt_rx->header.h_source);
+					DBG("\n Destination Address: ");
+					DBG_ADDR(pkt_rx->header.h_dest);
+
+					destroy_thread(); 
+					maap_info->state = INITIAL;
+					DBG("\nstate change to INITIAL");
+				}
+			}
+		} 
+		break;
+
+	default:
+		printf("Error: Undefined State\n");
+		break;
+	}
+
+	return 0;
+}
+
+
+void Init(maap_info_t *maap_info, uint8_t src_mac_adr[6])
+{
+	maap_pdu_t *maap_pkt = &maap_info->ethpkt.data;
+	uint8_t dest_mac[6];
+	int i;
+
+	DBG("Init\n");
+	maap_info->state = INITIAL;
+	maap_pkt->subtype          = MAAP_SUBTYPE; 
+	maap_pkt->cd               = 0x1; 
+	maap_pkt->message_type     = 0x0;
+	maap_pkt->version          = 0x0;
+	maap_pkt->sv               = 0x0;
+	maap_pkt->maap_version_data_length = hton_s(MAAP_VER_DATA_LEN);
+	maap_pkt->stream_id        = 0x00;
+	AGN_ADR(maap_pkt->requested_start_address, 0x00); 
+	AGN_ADR(maap_pkt->conflict_start_address, 0x00);
+	maap_pkt->requested_count = 0x00; 
+	maap_pkt->conflict_count  = 0x00;
+
+	get_multicast_mac_adr(dest_mac);
+	memcpy(maap_info->src_mac, src_mac_adr, MAC_ADDR_LEN);
+
+	memcpy(maap_info->ethpkt.header.h_dest, dest_mac, MAC_ADDR_LEN);
+	memcpy(maap_info->ethpkt.header.h_source, src_mac_adr, MAC_ADDR_LEN);
+	maap_info->ethpkt.header.eth_type = hton_s(ETH_TYPE);
+
+	maap_info->requested_mac_count = hton_s(0x0001);
+}
+
+void prepare_ethpkt(maap_info_t *maap_info, msg_type_t msg_type)
+{
+	ethpkt_t *pkt_tx = &maap_info->ethpkt;
+	ethpkt_t *pkt_rx = &maap_info->ethpkt_rx;
+	maap_pdu_t *maap_pkt = &maap_info->ethpkt.data;
+	uint8_t src_mac[6];
+	uint8_t dest_mac[6];
+	int i;
+
+	maap_pkt->message_type = msg_type;
+	memcpy(src_mac, maap_info->src_mac, MAC_ADDR_LEN);
+	get_multicast_mac_adr(dest_mac);
+
+	switch(msg_type)
+	{
+		case MAAP_PROBE:
+			memcpy(maap_pkt->requested_start_address,
+			       maap_info->requested_mac_add, MAC_ADDR_LEN);
+			AGN_ADR(maap_pkt->conflict_start_address, 0x00);
+			maap_pkt->requested_count =
+						maap_info->requested_mac_count;
+			maap_pkt->conflict_count  = 0x00;
+			memcpy(pkt_tx->header.h_dest, dest_mac, MAC_ADDR_LEN);
+			memcpy(pkt_tx->header.h_source, src_mac, MAC_ADDR_LEN);
+			break;
+
+		case MAAP_DEFEND:
+			memcpy(maap_pkt->requested_start_address,
+				maap_info->requested_mac_add, MAC_ADDR_LEN);
+			memcpy(maap_pkt->conflict_start_address,
+				maap_info->conflict_mac_add, MAC_ADDR_LEN);
+			maap_pkt->requested_count =
+				maap_info->requested_mac_count;
+			maap_pkt->conflict_count =
+				maap_info->conflict_mac_count;
+                        /* 
+                         * DEST_MAC set to source mac address received in
+                         * MAAP_PROBE
+                         */
+			memcpy(pkt_tx->header.h_dest, pkt_rx->header.h_source,
+			       MAC_ADDR_LEN); 
+			memcpy(pkt_tx->header.h_source, src_mac, MAC_ADDR_LEN);
+			break;
+
+		case MAAP_ANNOUNCE:
+			memcpy(maap_pkt->requested_start_address,
+				maap_info->acquired_mac_add, MAC_ADDR_LEN);
+			AGN_ADR(maap_pkt->conflict_start_address, 0x00);
+			maap_pkt->requested_count =
+						maap_info->acquired_mac_count;
+			maap_pkt->conflict_count  = 0x00;
+			memcpy(pkt_tx->header.h_dest, dest_mac, MAC_ADDR_LEN);
+			memcpy(pkt_tx->header.h_source, src_mac, MAC_ADDR_LEN);
+			break;
+
+		default:
+			printf("Error: Message type not set\n");
+			break;
+	}
+}
+
+/*
+ * compare MAC address from received MAAP PDU and receiving station MAC address
+ * return TRUE if they are same(different from what given in the protocol which is 
+ * to return TRUE if MAC address of receiving station is lower than received MAAP PDU)
+ */
+int compare_mac(uint8_t rcv_add[6], uint8_t req_addr[6])
+{
+	int i, flag = 0;
+
+	for (i=0; i<6; i++) {
+		if (rcv_add[i] == req_addr[i])
+		{
+			flag = 1; 
+		} else {
+			flag = 0;
+			break;
+		} 
+	}
+	return flag;
+}
+
+void *send_announce(void *maap_Info)
+{
+	maap_info_t *maap_info; 
+	maap_info = (maap_info_t *)maap_Info;
+
+	ethpkt_t *pkt_tx = &maap_info->ethpkt;
+
+	while(1)
+	{
+		delay(ANNOUNCE_TIMER_S, 0);
+		Lock();
+		prepare_ethpkt(maap_info, MAAP_ANNOUNCE);
+		send_packet(pkt_tx); 
+		UnLock();
+		printf("\nSENT MAAP_ANNOUNCE");
+	}
+}
+
+/* Multicast MAAP MAC address */
+void get_multicast_mac_adr(uint8_t *dest_mac) 
+{
+	dest_mac[0] = 0x91; 
+	dest_mac[1] = 0xE0; 
+	dest_mac[2] = 0xF0; 
+	dest_mac[3] = 0x00; 
+	dest_mac[4] = 0xFF; 
+	dest_mac[5] = 0x00; 
+}

--- a/daemons/maap/common/maap_protocol.h
+++ b/daemons/maap/common/maap_protocol.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2014 VAYAVYA LABS PVT LTD - http://vayavyalabs.com/
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU Lesser General Public License,
+ * version 2.1, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef __MAAP__PROTOCOL__
+
+#define __MAAP__PROTOCOL__
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#define MAAP_PROBE_RETRANSMITS			3
+#define MAAP_PROBE_INTERVAL_BASE_MS		500 
+#define MAAP_PROBE_INTERVAL_VARIATION_MS	100
+#define MAAP_ANNOUNCE_INTERVAL_BASE_S		30
+#define MAAP_ANNOUNCE_INTERVAL_VARIATION_S	2 
+
+#define PROBE_TIMER_MS rand_frange(MAAP_PROBE_INTERVAL_BASE_MS,\
+	MAAP_PROBE_INTERVAL_BASE_MS + MAAP_PROBE_INTERVAL_VARIATION_MS)
+#define ANNOUNCE_TIMER_S rand_frange(MAAP_ANNOUNCE_INTERVAL_BASE_S,\
+	MAAP_ANNOUNCE_INTERVAL_BASE_S + MAAP_ANNOUNCE_INTERVAL_VARIATION_S)
+
+#define MAAP_SUBTYPE		0x7E
+#define MAAP_VER_DATA_LEN	(((0x01 & 0x1F) << 11) | (0x010 & 0x7FF))
+#define ETH_TYPE		0x22F0
+#define ETH_PKT_LEN		sizeof(ethpkt_t) 
+#define MAC_ADDR_LEN		6 
+#define BLOCK			0 
+#define NON_BLOCK		1
+
+#define AGN_ADR(ADDR, val) for(i=0; i<MAC_ADDR_LEN; i++) {ADDR[i] = val;}
+
+/* states */
+typedef enum maap_state {
+	INITIAL = 0,
+	PROBE,
+	DEFEND,
+} state_t;    
+
+/* message types */
+typedef enum msg_type {
+	MAAP_PROBE = 1,
+	MAAP_DEFEND,
+	MAAP_ANNOUNCE
+} msg_type_t;
+
+/* Ethernet header */
+typedef struct ethhedr {
+	uint8_t h_dest[6];
+	uint8_t h_source[6];
+	uint16_t eth_type;
+} ethhedr_t; 
+
+/* MAAP PDU */
+typedef struct __attribute__ ((packed)) {
+	uint64_t subtype:7;
+	uint64_t cd:1;
+	uint64_t message_type:4;
+	uint64_t version:3;
+	uint64_t sv:1;
+	uint64_t maap_version_data_length:16;
+	uint64_t stream_id;
+	uint8_t requested_start_address[6];
+	uint16_t requested_count;
+	uint8_t conflict_start_address[6];
+	uint16_t conflict_count;
+} maap_pdu_t;
+
+/* structure to store packet header and data */
+typedef struct ethpacket {
+	ethhedr_t header;
+	maap_pdu_t data;
+} ethpkt_t;  
+
+/* MAAP Info private data structure */
+typedef struct maap_info {
+	ethpkt_t ethpkt;
+	ethpkt_t ethpkt_rx;
+	state_t state; 
+	uint8_t src_mac[6];
+	uint8_t requested_mac_add[6];
+	uint16_t requested_mac_count;
+	uint8_t acquired_mac_add[6];
+	uint16_t acquired_mac_count;
+	uint8_t conflict_mac_add[6];
+	uint16_t conflict_mac_count;
+} maap_info_t;
+
+/* 
+ * Function to initialize the pdu, header info and private data structure
+ * maap_info
+ */
+void Init(maap_info_t *, uint8_t *);
+
+/* Function to prepare ethernet packet */
+void prepare_ethpkt(maap_info_t *, msg_type_t);
+
+/* State transition */
+int state_transit(maap_info_t *);
+
+/* Get a random value within the range (min, max) */
+int rand_range(int , int);
+double rand_frange(double , double);
+
+/* Generate a random address from the MAAP Dynamic allocation range */
+void generate_address(maap_info_t *);
+
+/* Compare the Mac address and return 1 if address are same else return 0 */
+int compare_mac(uint8_t *, uint8_t *);
+
+/* Send MAAP_ANNOUNCE periodically with a delay of ANNOUNCE_TIMER */
+void *send_announce(void *);
+
+/* Get Multicast MAAP MAC Address */ 
+void get_multicast_mac_adr(uint8_t *);
+
+/* Create thread and Destroy thread */
+void create_thread(maap_info_t *, void *);
+void destroy_thread();
+
+/* Send and receive of ethernet packet */
+void send_packet(ethpkt_t *); 
+int recv_packet(ethpkt_t *, int);
+
+/* Delay based on the timer type passed */ 
+void delay(int , int ); 
+
+/* Lock and release */
+void Lock(); 
+void UnLock();
+uint16_t hton_s(uint16_t );
+
+//#define DEBUG
+#ifdef DEBUG
+#define DBG(x...) fprintf(stderr, x)
+#define DBG_ADDR(ADDR) for(i=0; i<MAC_ADDR_LEN; i++) { fprintf(stderr, "%#x " \
+		                      ,ADDR[i]); }
+#else
+#define DBG(x...) do {} while(0)
+#define DBG_ADDR(ADDR) for(i=0; i<MAC_ADDR_LEN; i++) { fprintf(stderr, "%#x " \
+		                      ,ADDR[i]); }
+//#define DBG_ADDR(ADDR) do {} while(0)
+#endif
+
+#endif

--- a/daemons/maap/linux/Makefile
+++ b/daemons/maap/linux/Makefile
@@ -1,0 +1,16 @@
+BUILD_DIR=../build
+COMMON_DIR=../common
+KER_VER=$(`uname -r`)
+INCFLAGS=$(COMMON_DIR)/maap_protocol.c 
+CFLAGS=$(OPT) -Wall
+EXTRA_FLAGS=-I$(COMMON_DIR) 
+FLAGS=-lpthread -lpcap
+
+all: maap_daemon
+
+maap_daemon: maap_linux.c
+	gcc -o $(BUILD_DIR)/maap_daemon $(INCFLAGS) maap_linux.c $(CFLAGS) $(FLAGS) $(EXTRA_FLAGS)
+	echo $(KER_VER)
+
+clean:
+	rm -rf $(BUILD_DIR)/maap_daemon

--- a/daemons/maap/linux/maap_linux.c
+++ b/daemons/maap/linux/maap_linux.c
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2014 VAYAVYA LABS PVT LTD - http://vayavyalabs.com/
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU Lesser General Public License,
+ * version 2.1, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <linux/if.h>
+
+#include <netinet/in.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <pthread.h>
+#include <inttypes.h>
+#include <unistd.h>
+
+#include "maap_protocol.h"
+
+uint8_t *maap_shm_mem;
+struct sockaddr_ll saddrll;
+pthread_t thread;
+pthread_mutex_t lock;
+int socketfd;
+
+int main(int argc, char *argv[]) 
+{
+	uint8_t *iface = NULL; 
+	struct ifreq buffer;
+	int ifindex;
+	struct packet_mreq mreq; 
+	maap_info_t *maap_Info;
+	uint32_t seed;
+	uint8_t dest_mac[6];
+	uint8_t src_mac[6];
+	int shmid;
+	key_t key;
+
+	if (argc < 2) {
+		printf("USAGE:%s <if_name>\n",argv[0]);
+		return -1;
+	} 
+
+	iface = (uint8_t *)argv[1];
+	if ((socketfd = socket(PF_PACKET, SOCK_RAW, htons(ETH_TYPE))) < 0 )
+	{
+		printf("Error: could not open socket %d\n",socketfd);
+		return -1;
+	}
+	memset(&buffer, 0x00, sizeof(buffer));
+	strncpy(buffer.ifr_name, (char *)iface, IFNAMSIZ);
+	if (ioctl(socketfd, SIOCGIFINDEX, &buffer) < 0)
+	{
+		printf("Error: could not get interface index\n");
+		close(socketfd);
+		return -1;
+	}
+
+	key = 1234;
+	if ((shmid = shmget(key, MAC_ADDR_LEN, IPC_CREAT | 0666)) < 0) {
+		printf("Error : Failed to allocate the Shared Memory\n");
+		close(socketfd);
+		return -1;
+	}
+
+	if ((maap_shm_mem = shmat(shmid, NULL, 0)) == (uint8_t *) -1) {
+		printf("Error : Failed to attach the created segment id by function \
+			shmget()");
+		close(socketfd);
+		return -1;
+	}
+  
+	ifindex = buffer.ifr_ifindex;
+	if (ioctl(socketfd, SIOCGIFHWADDR, &buffer) < 0) {
+		printf("Error: could not get interface address\n");
+		close(socketfd);
+		return -1;
+	}
+	memcpy(src_mac, buffer.ifr_hwaddr.sa_data, MAC_ADDR_LEN);
+
+	get_multicast_mac_adr(dest_mac);
+
+	memset((void*)&saddrll, 0, sizeof(saddrll));
+	saddrll.sll_family = AF_PACKET;
+	saddrll.sll_ifindex = ifindex;
+	saddrll.sll_halen = MAC_ADDR_LEN;
+	memcpy((void*)(saddrll.sll_addr), (void*)dest_mac, MAC_ADDR_LEN);
+
+	if (bind(socketfd, (struct sockaddr*)&saddrll, sizeof(saddrll))) {
+		printf("Error: could not bind datagram socket\n");
+		return -1;
+	}
+
+	/* filter multicast address */
+	memset(&mreq, 0, sizeof(mreq));
+	mreq.mr_ifindex = ifindex;
+	mreq.mr_type = PACKET_MR_MULTICAST;
+	mreq.mr_alen = 6;
+	memcpy(mreq.mr_address, dest_mac, mreq.mr_alen);
+
+	if (setsockopt(socketfd, SOL_PACKET, PACKET_ADD_MEMBERSHIP, &mreq,
+		sizeof(mreq)) < 0) {
+		printf("setsockopt PACKET_ADD_MEMBERSHIP failed\n");
+		return -1;
+	}
+
+	pthread_mutex_init(&(lock), NULL);
+	seed = src_mac[6] + time(NULL);
+	srand(seed);
+
+	maap_Info = (maap_info_t *)calloc(1,sizeof(maap_info_t));
+
+	/* Initialize packet header and data */
+	Init(maap_Info, src_mac);  
+
+	while (1) {
+		state_transit(maap_Info);
+	}
+
+	close(socketfd);
+
+	free(maap_Info);
+
+	return 0;
+}
+
+void delay(int seconds, int millisecond) 
+{
+	sleep(seconds);
+	usleep(millisecond * 1000);
+}
+
+void create_thread(maap_info_t *maap_info, void *announce) 
+{
+	pthread_create(&thread, NULL, announce, (void *)(maap_info));
+}
+
+void destroy_thread() 
+{
+	pthread_cancel(thread); 
+}
+
+double rand_frange(double min_n, double max_n)
+{
+	return (double)rand()/RAND_MAX * (max_n - min_n) + min_n;
+}
+
+int rand_range(int min_n, int max_n)
+{
+	return rand() % (max_n - min_n + 1) + min_n;
+}
+
+void send_packet(ethpkt_t *pkt_tx) 
+{
+	int result;
+	if ((result = (sendto(socketfd, pkt_tx, ETH_PKT_LEN, 0,
+			(struct sockaddr*)&saddrll, sizeof(saddrll)) > 0)))
+		DBG("send successful %d\n", result);
+	else   
+		DBG("Error: sending of packet failed\n");
+}  
+
+int recv_packet(ethpkt_t *pkt_rx, int flag)
+{
+	int result;
+	socklen_t fmlen = sizeof(saddrll);
+
+	if (flag == NON_BLOCK)
+		flag = MSG_DONTWAIT;
+
+	result = recvfrom(socketfd, pkt_rx, ETH_PKT_LEN, flag,
+			(struct sockaddr*)&saddrll, &fmlen); 
+	return result;
+} 
+
+void Lock()
+{
+	pthread_mutex_lock(&lock);
+}
+
+void UnLock()
+{
+	pthread_mutex_unlock(&lock);
+}
+
+uint16_t hton_s(uint16_t val)
+{
+	return htons(val);
+}


### PR DESCRIPTION
this patch adds support MAC address acquisition protocol
(MAAP). This protocol is used by the IEE722 to dynamically
allocate talker addresses.
This patch also includes a README which indicates the usage
of it.

Signed-off-by: Kiran Kodagali kiran.kodagali@vayavyalabs.com
Signed-off-by: Lad, Prabhakar prabhakar.lad@vayavyalabs.com
