### PR TITLE
MRP updates

### DIFF
--- a/daemons/mrpd/mmrp.c
+++ b/daemons/mrpd/mmrp.c
@@ -218,6 +218,7 @@ int mmrp_event(int event, struct mmrp_attribute *rattrib)
 		mrp_lvatimer_fsm(&(MMRP_db->mrp_db), MRP_EVENT_LVATIMER);
 
 		MMRP_db->send_empty_LeaveAll_flag = 1;
+		mrp_lvatimer_fsm(&(MMRP_db->mrp_db), MRP_EVENT_TX);
 		mmrp_txpdu();
 		MMRP_db->send_empty_LeaveAll_flag = 0;
 		break;
@@ -257,8 +258,6 @@ int mmrp_event(int event, struct mmrp_attribute *rattrib)
 					  &(attrib->applicant), MRP_EVENT_TX);
 			attrib = attrib->next;
 		}
-
-		mrp_lvatimer_fsm(&(MMRP_db->mrp_db), MRP_EVENT_TX);
 
 		mmrp_txpdu();
 		break;

--- a/daemons/mrpd/mrp.c
+++ b/daemons/mrpd/mrp.c
@@ -370,7 +370,6 @@ int mrp_lvatimer_fsm(struct mrp_database *mrp_db, int event)
 		mrp_lvatimer_start(mrp_db);
 		break;
 	case MRP_EVENT_LVATIMER:
-		tx = 1;
 		la_state = MRP_TIMER_ACTIVE;
 		mrp_lvatimer_stop(mrp_db);
 		mrp_lvatimer_start(mrp_db);

--- a/daemons/mrpd/msrp.c
+++ b/daemons/mrpd/msrp.c
@@ -312,6 +312,13 @@ int msrp_event(int event, struct msrp_attribute *rattrib)
 		mrp_lvatimer_fsm(&(MSRP_db->mrp_db), MRP_EVENT_LVATIMER);
 
 		MSRP_db->send_empty_LeaveAll_flag = 1;
+		/*
+		 * We are going to emit a PDU here, so call lva FSM with
+		 * TX event so as to set the lva.tx=1 flag prior to sending
+		 * the PDU. After the pdu is sent, lva.tx=0 and the lva
+		 * LSM is back to the passive state.
+		 */
+		mrp_lvatimer_fsm(&(MSRP_db->mrp_db), MRP_EVENT_TX);
 		msrp_txpdu();
 		MSRP_db->send_empty_LeaveAll_flag = 0;
 		break;
@@ -362,8 +369,12 @@ int msrp_event(int event, struct msrp_attribute *rattrib)
 #if LOG_MSRP
 		msrp_update_log_filter(NULL);
 #endif
-		mrp_lvatimer_fsm(&(MSRP_db->mrp_db), MRP_EVENT_TX);
-
+		/*
+		 * Don't need to call mrp_lvatimer_fsm(..., MRP_EVENT_TX) from
+		 * here because the TX event only ever does anything in the
+		 * lva FSM when the start is active, and it is only active
+		 * momentarily after a LVATIMER event.
+		 */
 		msrp_txpdu();
 		break;
 	case MRP_EVENT_LVTIMER:

--- a/daemons/mrpd/mvrp.c
+++ b/daemons/mrpd/mvrp.c
@@ -168,6 +168,7 @@ int mvrp_event(int event, struct mvrp_attribute *rattrib)
 		mrp_lvatimer_fsm(&(MVRP_db->mrp_db), MRP_EVENT_LVATIMER);
 
 		MVRP_db->send_empty_LeaveAll_flag = 1;
+		mrp_lvatimer_fsm(&(MVRP_db->mrp_db), MRP_EVENT_TX);
 		mvrp_txpdu();
 		MVRP_db->send_empty_LeaveAll_flag = 0;
 		break;
@@ -202,8 +203,6 @@ int mvrp_event(int event, struct mvrp_attribute *rattrib)
 					  &(attrib->applicant), MRP_EVENT_TX);
 			attrib = attrib->next;
 		}
-
-		mrp_lvatimer_fsm(&(MVRP_db->mrp_db), MRP_EVENT_TX);
 
 		mvrp_txpdu();
 		break;


### PR DESCRIPTION
This pull request contains 3 independent updates:
1) notify mrpd clients as soon as attribute transitions to MT - no change to MRP packets on the wire.
(this enables a talker to stop streaming AVTP packets more quickly)
2) verify dest mac address for all incoming frames
3) update leaveAllTimer event processing to fix emitting multiple pdus with leaveAll flag set.
