### PR TITLE
Bug fix: Two consecutive right shifts of correctionField

### DIFF
--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1003,7 +1003,7 @@ void PTPMessageFollowUp::processMessage(IEEE1588Port * port)
 
 	correctionField = (uint64_t)
 		((correctionField >> 16)/master_local_freq_offset);
-	correction = (int) (delay + (correctionField >> 16));
+	correction = (int) (delay + correctionField);
 	corrected_sync_time = sync_arrival;
 	
 	if( correction > 0 )


### PR DESCRIPTION
Bug fix: Two consecutive right shifts of correctionField by 16 bits in FollowUp message processing -> severe impact on time sync accuracy
