### PR TITLE
igb_clean: continue instead of return

### DIFF
--- a/lib/igb/igb.c
+++ b/lib/igb/igb.c
@@ -1023,7 +1023,7 @@ igb_clean(device_t *dev, struct igb_packet **cleaned_packets)
 
 		if (txr->tx_avail == adapter->num_tx_desc) {
 			txr->queue_status = IGB_QUEUE_IDLE;
-			return;
+			continue;
 		}
 	
 		processed = 0;


### PR DESCRIPTION
If using only Class B traffic igb_clean will fail as tx_ring for Class A has nothing to be cleaned up and function returns. So call continue to check on Class B.
