### PR TITLE
gtpt/linux: Fix compilation issue related to type redefinition

### DIFF
--- a/daemons/gptp/linux/src/ipcdef.hpp
+++ b/daemons/gptp/linux/src/ipcdef.hpp
@@ -34,6 +34,7 @@
 #ifndef IPCDEF_HPP
 #define IPCDEF_HPP
 
+#include <sys/types.h>
 #include <ptptypes.hpp>
 
 typedef enum {

--- a/daemons/gptp/linux/src/linux_hal_generic_adj.cpp
+++ b/daemons/gptp/linux/src/linux_hal_generic_adj.cpp
@@ -32,6 +32,9 @@
 ******************************************************************************/
 
 #include <linux/timex.h>
+ // avoid indirect inclusion of time.h since this will clash with linux/timex.h
+#define _TIME_H  1
+#define _STRUCT_TIMEVAL 1
 #include <linux_hal_generic.hpp>
 #include <syscall.h>
 #include <math.h>


### PR DESCRIPTION
Linux gptp currently fails to build due to missing include. This commit should fix that and avoid a type redefinition conflict between time.h and linux/time.h.
