### PR TITLE
daemons: common: parse.c, fix coverity detected varible init issue

### DIFF
--- a/daemons/common/parse.c
+++ b/daemons/common/parse.c
@@ -63,7 +63,7 @@ int parse(char *s, int len, struct parse_param *specs, int *err_index)
 	const char *guard;
 	unsigned int v_uint;
 	uint64_t v_uint64;
-	int result;
+	int result = 0;
 	int count = 0;
 
 	/* make sure string is null terminated */


### PR DESCRIPTION
This pull request fixes a potential issue. It is not expected to impact any existing code in any way what-so-ever as the exact path followed by coverity static analysis would not occur in real use. However, better to have a clean coverity report if at all possible.
