### PR TITLE
Fix for Coverity CID71708 - buffer not terminated

### DIFF
--- a/daemons/mrpd/mrpd.c
+++ b/daemons/mrpd/mrpd.c
@@ -459,7 +459,7 @@ mrpd_init_protocol_socket(u_int16_t etype, int *sock,
 
 	memset(&if_request, 0, sizeof(if_request));
 
-	strncpy(if_request.ifr_name, interface, sizeof(if_request.ifr_name));
+	strncpy(if_request.ifr_name, interface, sizeof(if_request.ifr_name)-1);
 
 	rc = ioctl(lsock, SIOCGIFINDEX, &if_request);
 	if (rc < 0) {


### PR DESCRIPTION
strncpy doesn't leave room for a NULL terminator if the string is longer than the size you pass it, so we must pass it one less than the full length to ensure the string is always terminated.
