### PR TITLE
Remove some active but useless lines from MMRP

### DIFF
--- a/daemons/mrpd/mmrp.c
+++ b/daemons/mrpd/mmrp.c
@@ -632,9 +632,6 @@ int mmrp_recv_msg()
 				/* as either firstval is either 0 or 1 ... the common
 				 * case will be nulls for evt_2 and evt_3 ...
 				 */
-				if (MRPDU_VECT_LVA
-				    (ntohs(mrpdu_vectorptr->VectorHeader)))
-					mmrp_event(MRP_EVENT_RLA, NULL);
 
 				/* 2 byte numvalues + 34 byte FirstValue + (n) vector bytes */
 				mrpdu_msg_ptr = (uint8_t *) mrpdu_vectorptr;


### PR DESCRIPTION
The code removed seems to be leftover copy-paste mess from MVRP;
it is incorrect in MMRP, but the correct operation is done at the
beginning of the function and the leftover lines don't have any
ill effect due to the NULL check in the called code.

There should be no runtime behavioral change due to this.

This addresses issue #147
