### PR TITLE
gPTP: redundant (false) LINKUP events filtering

### DIFF
--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -237,6 +237,9 @@ typedef struct {
 	/* Set to true if the port is the grandmaster. Used for fixed GM in the the AVnu automotive profile */
 	bool testMode;
 
+	/* Set to true if the port's network interface is up. Used to filter false LINKUP/LINKDOWN events */
+	bool linkUp;
+
 	/* gPTP 10.2.4.4 */
 	char initialLogSyncInterval;
 
@@ -306,6 +309,7 @@ class IEEE1588Port {
 	unsigned sync_count;  // 0 for master, ++ for each sync receive as slave
 	// set to 0 when asCapable is false, increment for each pdelay recvd
 	unsigned pdelay_count;
+	bool linkUp;
 
 	/* Port Configuration */
 	unsigned char delay_mechanism;
@@ -1516,6 +1520,23 @@ class IEEE1588Port {
 	 */
 	bool getTestMode(void) {
 		return testMode;
+	}
+
+	/**
+	 * @brief  Sets the linkUp status
+	 * @param  bool of the linkUp status
+	 * @return void
+	 */
+	void setLinkUpState(bool state) {
+		linkUp = state;
+	}
+
+	/**
+	 * @brief  Gets the linkUp status
+	 * @return bool of the linkUp status
+	 */
+	bool getLinkUpState(void) {
+		return linkUp;
 	}
 
 	/**

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -96,6 +96,7 @@ IEEE1588Port::IEEE1588Port(IEEE1588PortInit_t *portInit)
 	automotive_profile = portInit->automotive_profile;
 	isGM = portInit->isGM;
 	testMode = portInit->testMode;
+	linkUp = portInit->linkUp;
 	initialLogSyncInterval = portInit->initialLogSyncInterval;
 	initialLogPdelayReqInterval = portInit->initialLogPdelayReqInterval;
 	operLogPdelayReqInterval = portInit->operLogPdelayReqInterval;

--- a/daemons/gptp/linux/src/daemon_cl.cpp
+++ b/daemons/gptp/linux/src/daemon_cl.cpp
@@ -150,6 +150,7 @@ int main(int argc, char **argv)
 	portInit.automotive_profile = false;
 	portInit.isGM = false;
 	portInit.testMode = false;
+	portInit.linkUp = false;
 	portInit.initialLogSyncInterval = LOG2_INTERVAL_INVALID;
 	portInit.initialLogPdelayReqInterval = LOG2_INTERVAL_INVALID;
 	portInit.operLogPdelayReqInterval = LOG2_INTERVAL_INVALID;

--- a/daemons/gptp/linux/src/linux_hal_common.cpp
+++ b/daemons/gptp/linux/src/linux_hal_common.cpp
@@ -205,11 +205,18 @@ static void x_readEvent(int sockint, IEEE1588Port *pPort, int ifindex)
 		if (msgHdr->nlmsg_type == RTM_NEWLINK) {
 			ifi = (struct ifinfomsg *)NLMSG_DATA(msgHdr);
 			if (ifi->ifi_index == ifindex) {
-				if ((ifi->ifi_flags & IFF_RUNNING)) {
-					pPort->processEvent(LINKUP);
+				bool linkUp = ifi->ifi_flags & IFF_RUNNING;
+				if (linkUp != pPort->getLinkUpState()) {
+					pPort->setLinkUpState(linkUp);
+					if (linkUp) {
+						pPort->processEvent(LINKUP);
+					}
+					else {
+						pPort->processEvent(LINKDOWN);
+					}
 				}
 				else {
-					pPort->processEvent(LINKDOWN);
+					GPTP_LOG_DEBUG("False (repeated) %s event for the interface", linkUp ? "LINKUP" : "LINKDOWN");
 				}
 			}
 		}


### PR DESCRIPTION
Mulitple LINKUP events are observed during interface manipulations
(e.g. adding or removing VLANs), so this change checks when
the ifi_flags gets IFF_RUNNING bit changed.