### PR TITLE
S3 test and reboot test fixes - memory corruption/NULL ptr dereference

### DIFF
--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -10409,7 +10409,7 @@ static long igb_mapbuf(struct file *file, void __user *arg, int ring)
 		}
 		
 		if(!adapter->num_tx_queues) {
-			printk("tx ring freed\n");
+			printk("Tx_queues number cleared, tx ring freed - preventing from dereferencing NULL pointer\n");
 			return -EINVAL;
 		}
 
@@ -10434,7 +10434,7 @@ static long igb_mapbuf(struct file *file, void __user *arg, int ring)
 		}
 
 		if(!adapter->num_rx_queues) {
-			printk("rx ring freed\n");
+			printk("Rx_queues number cleared, rx ring freed - preventing from dereferencing NULL pointer\n");
 			return -EINVAL;
 		}
 

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -10407,6 +10407,11 @@ static long igb_mapbuf(struct file *file, void __user *arg, int ring)
 			       req.queue);
 			return -EINVAL;
 		}
+		
+		if(!adapter->num_tx_queues) {
+			printk("tx ring freed\n");
+			return -EINVAL;
+		}
 
 		mutex_lock(&adapter->lock);
 		if (adapter->uring_tx_init & (1 << req.queue)) {
@@ -10425,6 +10430,11 @@ static long igb_mapbuf(struct file *file, void __user *arg, int ring)
 		if (req.queue >= 3) {
 			printk("mapring:invalid queue specified(%d)\n",
 			       req.queue);
+			return -EINVAL;
+		}
+
+		if(!adapter->num_rx_queues) {
+			printk("rx ring freed\n");
 			return -EINVAL;
 		}
 

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -10409,7 +10409,7 @@ static long igb_mapbuf(struct file *file, void __user *arg, int ring)
 		}
 		
 		if(!adapter->num_tx_queues) {
-			printk("Tx_queues number cleared, tx ring freed - preventing from dereferencing NULL pointer\n");
+			printk("igb_avb igb_mapbuf:tx ring freed %s\n", adapter->netdev->name);
 			return -EINVAL;
 		}
 
@@ -10434,7 +10434,7 @@ static long igb_mapbuf(struct file *file, void __user *arg, int ring)
 		}
 
 		if(!adapter->num_rx_queues) {
-			printk("Rx_queues number cleared, rx ring freed - preventing from dereferencing NULL pointer\n");
+			printk("igb_avb igb_mapbuf:rx ring freed %s \n", adapter->netdev->name);
 			return -EINVAL;
 		}
 

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -3318,15 +3318,17 @@ static int __igb_open(struct net_device *netdev, bool resuming)
 
 	netif_carrier_off(netdev);
 
-	/* allocate transmit descriptors */
-	err = igb_setup_all_tx_resources(adapter);
-	if (err)
-		goto err_setup_tx;
+	if(!resuming){
+		/* allocate transmit descriptors */
+		err = igb_setup_all_tx_resources(adapter);
+		if (err)
+			goto err_setup_tx;
 
-	/* allocate receive descriptors */
-	err = igb_setup_all_rx_resources(adapter);
-	if (err)
-		goto err_setup_rx;
+		/* allocate receive descriptors */
+		err = igb_setup_all_rx_resources(adapter);
+		if (err)
+			goto err_setup_rx;
+	}
 
 	igb_power_up_link(adapter);
 
@@ -3438,8 +3440,10 @@ static int __igb_close(struct net_device *netdev, bool suspending)
 
 	igb_free_irq(adapter);
 
-	igb_free_all_tx_resources(adapter);
-	igb_free_all_rx_resources(adapter);
+	if(!suspending || (system_state != SYSTEM_RUNNING)){
+		igb_free_all_tx_resources(adapter);
+		igb_free_all_rx_resources(adapter);
+	}
 
 #ifdef CONFIG_PM_RUNTIME
 	if (!suspending)
@@ -9188,7 +9192,8 @@ static int __igb_shutdown(struct pci_dev *pdev, bool *enable_wake,
 	if (netif_running(netdev))
 		__igb_close(netdev, true);
 
-	igb_clear_interrupt_scheme(adapter);
+	if(system_state != SYSTEM_RUNNING)
+		igb_clear_interrupt_scheme(adapter);
 
 #ifdef CONFIG_PM
 	retval = pci_save_state(pdev);
@@ -9294,12 +9299,6 @@ static int igb_resume(struct pci_dev *pdev)
 
 	pci_enable_wake(pdev, PCI_D3hot, 0);
 	pci_enable_wake(pdev, PCI_D3cold, 0);
-
-	if (igb_init_interrupt_scheme(adapter, true)) {
-		dev_err(pci_dev_to_dev(pdev),
-			"Unable to allocate memory for queues\n");
-		return -ENOMEM;
-	}
 
 	igb_reset(adapter);
 


### PR DESCRIPTION
1. commit be07cb5
Fixing dma memory corruption during suspend - during S3 test there was a discovery of a memory corruption resulting in kernel panic. That was caused by memory beeing freed within suspend function. Keeping the memory in driver suspend prevents from the uexpected fatal behaviour

2. commit 7265634
Checking Tx and Rx queues number in igb_mapbuf - change due to kernel NULL pointer dereference in reboot test. There is a possibility that user space calls igb_ioctl_fila -> igb_mapbuf after the ring has been reset (and the tx/rx_rings have been NULL'ed). Therefore the patch check if tx and rx queues numbers are cleared to zero before accessing adapters tx_ring and rx_ring in igb_mapbuf