### PR TITLE
MAAP daemon updates

### DIFF
--- a/daemons/maap/common/maap.h
+++ b/daemons/maap/common/maap.h
@@ -228,11 +228,12 @@ void add_notify(Maap_Client *mc, const void *sender, const Maap_Notify *mn);
 int get_notify(Maap_Client *mc, const void **sender, Maap_Notify *mn);
 
 /**
- * Output the text equivalent of the notification information to stdout.
+ * Output the text equivalent of the notification information to the callback function.
  *
  * @param mn Pointer to the notification information structure.
- * @param outputType One or more of the #Maap_Output_Type flag values.
+ * @param notify_callback Function of type #print_notify_callback_t that will handle printable results.
+ * @param callback_data Data to return with the callback.
  */
-void print_notify(Maap_Notify *mn, Maap_Output_Type outputType);
+void print_notify(Maap_Notify *mn, print_notify_callback_t notify_callback, void *callback_data);
 
 #endif

--- a/daemons/maap/common/maap_iface.h
+++ b/daemons/maap/common/maap_iface.h
@@ -101,10 +101,7 @@ typedef struct {
 } Maap_Notify;
 
 
-/** MAAP Output Type Desired Flags */
-typedef enum {
-	MAAP_OUTPUT_LOGGING = 0x01,       /**< Send the results to the logging engine */
-	MAAP_OUTPUT_USER_FRIENDLY = 0x02, /**< Send the results to stdout in user-friendly format */
-} Maap_Output_Type;
+/** Callback function used by #print_notify and #print_cmd_usage */
+typedef void (*print_notify_callback_t)(void *callback_data, int logLevel, const char *notifyText);
 
 #endif

--- a/daemons/maap/common/maap_parse.c
+++ b/daemons/maap/common/maap_parse.c
@@ -182,8 +182,6 @@ void parse_usage(print_notify_callback_t print_callback, void *callback_data)
 {
 	char szOutput[100];
 	print_callback(callback_data, MAAP_LOG_LEVEL_INFO,
-		"Invalid command type");
-	print_callback(callback_data, MAAP_LOG_LEVEL_INFO,
 		"Input usage:");
 	print_callback(callback_data, MAAP_LOG_LEVEL_INFO,
 		"    init [<range_base> <range_size>] - Initialize the MAAP daemon to recognize");

--- a/daemons/maap/common/maap_parse.h
+++ b/daemons/maap/common/maap_parse.h
@@ -53,10 +53,18 @@ int parse_text_cmd(char *buf, Maap_Cmd *cmd);
  * @param mc Pointer to the Maap_Client structure to use
  * @param sender Sender information pointer used to track the entity requesting the command
  * @param buf Binary or text data to parse
- * @param outputType One or more of the #Maap_Output_Type flag values.
+ * @param input_is_text Optional pointer for variable set to 1 if the input is text, 0 if the input is binary.
  *
- * @return 1 if the exit command was received, 0 otherwise.
+ * @return 1 if the exit command was received, -1 for an unrecognized command, or 0 otherwise.
  */
-int parse_write(Maap_Client *mc, const void *sender, char *buf, Maap_Output_Type outputType);
+int parse_write(Maap_Client *mc, const void *sender, char *buf, int *input_is_text);
+
+/**
+ * Prints the usage expected for parsing.
+ *
+ * @param print_callback Function of type #print_notify_callback_t that will handle printable results.
+ * @param callback_data Data to return with the callback.
+ */
+void parse_usage(print_notify_callback_t print_callback, void *callback_data);
 
 #endif /* MAAP_PARSE_H_ */

--- a/daemons/maap/linux/src/maap_daemon.c
+++ b/daemons/maap/linux/src/maap_daemon.c
@@ -796,7 +796,7 @@ static int act_as_client(const char *listenport)
 		/* Handle any responses received. */
 		if (FD_ISSET(socketfd, &read_fds))
 		{
-			while ((recvbytes = recv(socketfd, recvbuffer, sizeof(recvbuffer) - 1, 0)) > 0)
+			while ((recvbytes = recv(socketfd, recvbuffer, sizeof(Maap_Notify), 0)) > 0)
 			{
 				recvbuffer[recvbytes] = '\0';
 

--- a/daemons/maap/linux/src/maap_daemon.c
+++ b/daemons/maap/linux/src/maap_daemon.c
@@ -332,6 +332,10 @@ static int act_as_server(const char *listenport, char *iface, int daemonize)
 	 */
 
 	MAAP_LOG_STATUS("Server started");
+	if (!daemonize) {
+		puts("Enter \"help\" for a list of valid commands.");
+	}
+
 	while (!exit_received)
 	{
 		/* Send any queued packets. */
@@ -507,6 +511,9 @@ static int act_as_server(const char *listenport, char *iface, int daemonize)
 				else if (result < 0)
 				{
 					/* Invalid command.  Tell the user what valid commands are. */
+					if (strncmp(recvbuffer, "help", 4) != 0) {
+						puts("Invalid command type");
+					}
 					parse_usage(display_print_notify_result, NULL);
 				}
 			}
@@ -549,6 +556,9 @@ static int act_as_server(const char *listenport, char *iface, int daemonize)
 					else if (result < 0)
 					{
 						/* Invalid command.  Tell the user what valid commands are. */
+						if (strncmp(recvbuffer, "help", 4) != 0) {
+							send_print_notify_result((void *) &(clientfd[i]), MAAP_LOG_LEVEL_INFO, "Invalid command type");
+						}
 						parse_usage(send_print_notify_result, (void *) &(clientfd[i]));
 					}
 				}
@@ -769,7 +779,9 @@ static int act_as_client(const char *listenport)
 	 * Main event loop
 	 */
 
-	printf("Client started\n");
+	puts("Client started");
+	puts("Enter \"help\" for a list of valid commands.");
+
 	while (!exit_received)
 	{
 		/* Wait for something to happen. */
@@ -841,6 +853,9 @@ static int act_as_client(const char *listenport)
 					memset(&recvcmd, 0, sizeof(Maap_Cmd));
 					rv = parse_text_cmd(recvbuffer, &recvcmd);
 					if (!rv) {
+						if (strncmp(recvbuffer, "help", 4) != 0) {
+							puts("Invalid command type");
+						}
 						parse_usage(display_print_notify_result, NULL);
 					}
 					break;
@@ -963,6 +978,7 @@ static void format_print_notify_result(int logLevel, const char *notifyText, cha
 			/* Print the remainder of the string. */
 			strcpy(pszOut, notifyText);
 			pszOut += strlen(pszOut);
+			*pszOut++ = '\r'; // Useful for Telnet interaction
 			*pszOut++ = '\n';
 			break;
 		}
@@ -971,6 +987,7 @@ static void format_print_notify_result(int logLevel, const char *notifyText, cha
 		for (i = 0; i < nLastSpace; ++i) {
 			*pszOut++ = *notifyText++;
 		}
+		*pszOut++ = '\r'; // Useful for Telnet interaction
 		*pszOut++ = '\n';
 
 		/* Go to the start of the next word in the string. */


### PR DESCRIPTION
Restructured the MAAP daemon to make the code more generic.
Clients that want to interact with the MAAP daemon using text (such as telnet clients) are now supported.
Added prompt to tell the user to type "help" for commands.
Fixed an issue when receiving multiple binary notifications.
Fixed some memory leaks with invalid command-line flags.