### PR TITLE
Added YIELD command support to the MAAP daemon

### DIFF
--- a/daemons/maap/common/maap.h
+++ b/daemons/maap/common/maap.h
@@ -176,6 +176,20 @@ int maap_release_range(Maap_Client *mc, const void *sender, int id);
  */
 void maap_range_status(Maap_Client *mc, const void *sender, int id);
 
+/**
+ * Yield a reserved block of addresses, in support of a MAAP_CMD_YIELD command.
+ *
+ * @note This call starts the yield process, which is only useful for testing.
+ * A MAAP_NOTIFY_YIELDED notification will be sent when the process is complete.
+ *
+ * @param mc Pointer to the Maap_Client structure to use
+ * @param sender Sender information pointer used to track the entity requesting the command
+ * @param id Identifier for the address block to yield
+ *
+ * @return 0 if the yield was started successfully, -1 otherwise.
+ */
+int maap_yield_range(Maap_Client *mc, const void *sender, int id);
+
 
 /**
  * Processing for a received (incoming) networking packet

--- a/daemons/maap/common/maap_iface.h
+++ b/daemons/maap/common/maap_iface.h
@@ -45,6 +45,7 @@ typedef enum {
 	MAAP_CMD_RESERVE, /**< Preserve a block of addresses within the initialized range */
 	MAAP_CMD_RELEASE, /**< Release a previously-reserved block of addresses */
 	MAAP_CMD_STATUS,  /**< Return the block of reserved addresses associated with the supplied ID */
+	MAAP_CMD_YIELD,   /**< Yield a previously-reserved block of addresses.  This is only useful for testing. */
 	MAAP_CMD_EXIT,    /**< Have the daemon exit */
  } Maap_Cmd_Tag;
 
@@ -55,7 +56,7 @@ typedef enum {
  */
 typedef struct {
 	Maap_Cmd_Tag kind; /**< Type of command to perform */
-	int32_t  id;       /**< ID to use for #MAAP_CMD_RELEASE or #MAAP_CMD_STATUS */
+	int32_t  id;       /**< ID to use for #MAAP_CMD_RELEASE, #MAAP_CMD_STATUS, or #MAAP_CMD_YIELD */
 	uint64_t start;    /**< Address range start for #MAAP_CMD_INIT */
 	uint32_t count;    /**< Address range size for #MAAP_CMD_INIT, or address block size for #MAAP_CMD_RESERVE */
 } Maap_Cmd;

--- a/daemons/maap/common/maap_parse.c
+++ b/daemons/maap/common/maap_parse.c
@@ -93,6 +93,10 @@ int parse_text_cmd(char *buf, Maap_Cmd *cmd) {
 			cmd->kind = MAAP_CMD_STATUS;
 			cmd->id = (int)strtoul(argv[1], NULL, 0);
 			set_cmd = 1;
+		} else if (strncmp(argv[0], "yield", 7) == 0 && argc == 2) {
+			cmd->kind = MAAP_CMD_YIELD;
+			cmd->id = (int)strtoul(argv[1], NULL, 0);
+			set_cmd = 1;
 		} else if (strncmp(argv[0], "exit", 4) == 0 && argc == 1) {
 			cmd->kind = MAAP_CMD_EXIT;
 			set_cmd = 1;
@@ -114,6 +118,7 @@ int parse_write(Maap_Client *mc, const void *sender, char *buf, int *input_is_te
 	case MAAP_CMD_RESERVE:
 	case MAAP_CMD_RELEASE:
 	case MAAP_CMD_STATUS:
+	case MAAP_CMD_YIELD:
 	case MAAP_CMD_EXIT:
 		if (input_is_text) { *input_is_text = 0; }
 		memcpy(&cmd, bufcmd, sizeof (Maap_Cmd));
@@ -162,6 +167,12 @@ int parse_write(Maap_Client *mc, const void *sender, char *buf, int *input_is_te
 #endif
 			maap_range_status(mc, sender, cmd.id);
 			break;
+		case MAAP_CMD_YIELD:
+#ifdef DEBUG_CMD_MSG
+			MAAP_LOGF_DEBUG("Got cmd MAAP_CMD_YIELD, id: %d", (int) cmd.id);
+#endif
+			rv = maap_yield_range(mc, sender, cmd.id);
+			break;
 		case MAAP_CMD_EXIT:
 #ifdef DEBUG_CMD_MSG
 			MAAP_LOG_DEBUG("Got cmd MAAP_CMD_EXIT");
@@ -200,6 +211,10 @@ void parse_usage(print_notify_callback_t print_callback, void *callback_data)
 		"    release <id> - Release the range of addresses with identifier ID");
 	print_callback(callback_data, MAAP_LOG_LEVEL_INFO,
 		"    status <id> - Get the range of addresses associated with identifier ID");
+	print_callback(callback_data, MAAP_LOG_LEVEL_INFO,
+		"    yield <id> - Yield the range of addresses associated with identifier ID.");
+	print_callback(callback_data, MAAP_LOG_LEVEL_INFO,
+		"        This is only useful for testing.");
 	print_callback(callback_data, MAAP_LOG_LEVEL_INFO,
 		"    exit - Shutdown the MAAP daemon");
 	print_callback(callback_data, MAAP_LOG_LEVEL_INFO,

--- a/daemons/maap/linux/src/maap_daemon.c
+++ b/daemons/maap/linux/src/maap_daemon.c
@@ -845,6 +845,7 @@ static int act_as_client(const char *listenport)
 				case MAAP_CMD_RESERVE:
 				case MAAP_CMD_RELEASE:
 				case MAAP_CMD_STATUS:
+				case MAAP_CMD_YIELD:
 				case MAAP_CMD_EXIT:
 					memcpy(&recvcmd, bufcmd, sizeof(Maap_Cmd));
 					rv = 1;


### PR DESCRIPTION
This update provides an easy way to test the "yield" behavior of daemon clients.  This state occurs when a MAAP DEFEND PDU is received by the MAAP daemon from a device with a lower MAC Address that conflicts with a multicast address being defended by the daemon.  When the conflict occurs (either by receiving an applicable MAAP DEFEND PDU, or by using the "yield" command), the daemon client with the conflicting reservation will receive a MAAP_NOTIFY_YIELDED notification, followed by MAAP_NOTIFY_ACQUIRING and MAAP_NOTIFY_ACQUIRED notifications for the newly reserved MAAP multicast address.