### PR TITLE
Windows 10 detection fix

### DIFF
--- a/daemons/gptp/CMakeLists.txt
+++ b/daemons/gptp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 project (gptp)
 
 include_directories( "./common" )
@@ -18,7 +18,7 @@ elseif(WIN32)
   # HAVE_REMOTE change pcap include options
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -DHAVE_REMOTE)
   include_directories( include "./windows/daemon_cl" $ENV{WPCAP_DIR}/Include )
-  file(GLOB GPTP_OS "./windows/daemon_cl/*.cpp")
+  file(GLOB GPTP_OS "./windows/daemon_cl/*.cpp" "./windows/daemon_cl/gptp.manifest")
   add_executable (gptp ${GPTP_COMMON} ${GPTP_OS})
   target_link_libraries(gptp wpcap Iphlpapi Ws2_32)
 

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1030,7 +1030,7 @@ void PTPMessageFollowUp::processMessage( EtherPort *port )
 
 	/* Adjust local_clock to correspond to sync_arrival */
 	device_sync_time_offset =
-	    TIMESTAMP_TO_NS(device_time) - TIMESTAMP_TO_NS(sync_arrival);
+		(uint32_t) (TIMESTAMP_TO_NS(device_time) - TIMESTAMP_TO_NS(sync_arrival));
 
 	GPTP_LOG_VERBOSE
 	    ("ptp_message::FollowUp::processMessage System time: %u,%u "

--- a/daemons/gptp/windows/daemon_cl/gptp.manifest
+++ b/daemons/gptp/windows/daemon_cl/gptp.manifest
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<asmv1:assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1" xmlns:asmv2="urn:schemas-microsoft-com:asm.v2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows Vista and Windows Server 2008 -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"></supportedOS>
+
+      <!-- Windows 7 and Windows Server 2008 R2 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+
+      <!-- Windows 8 and Windows Server 2012 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"></supportedOS>
+
+      <!-- Windows 8.1 and Windows Server 2012 R2 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+
+    </application>
+  </compatibility>
+</asmv1:assembly>


### PR DESCRIPTION
Added a manifest indicating Windows 10 support to the Windows gPTP build, so that Windows 10 detection will work correctly.  Manifest support is available with CMake 3.4 and later.
Also changed ptp_message.cpp to address a x64 compile warning.
Note that these changes were only tested with Microsoft Visual Studio Premium 2012 Update 5, and not with any other compilers.