### PR TITLE
Ignore twoStepFlag as per Table 11-4 of 802.1AS-2011

### DIFF
--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -840,7 +840,9 @@ void PTPMessageSync::processMessage( EtherPort *port )
 
 	port->incCounter_ieee8021AsPortStatRxSyncCount();
 
+#if CHECK_ASSIST_BIT
 	if( flags[PTP_ASSIST_BYTE] & (0x1<<PTP_ASSIST_BIT)) {
+#endif
 		PTPMessageSync *old_sync = port->getLastSync();
 
 		if (old_sync != NULL) {
@@ -849,11 +851,13 @@ void PTPMessageSync::processMessage( EtherPort *port )
 		port->setLastSync(this);
 		_gc = false;
 		goto done;
+#if CHECK_ASSIST_BIT
 	} else {
 		GPTP_LOG_ERROR("PTP assist flag is not set, discarding invalid sync");
 		_gc = true;
 		goto done;
 	}
+#endif
 
  done:
 	return;


### PR DESCRIPTION
As the twoStepFlag value is not used, and should be ignored, added a change to not test that the flag is set.
This allows the gPTP daemon to work with switches, such as MOTU, that do not set this flag.