### PR TITLE
gPTP: add negative time jumps detection

### DIFF
--- a/daemons/gptp/common/avbts_clock.hpp
+++ b/daemons/gptp/common/avbts_clock.hpp
@@ -61,6 +61,9 @@
    adjustment is performed */
 #define PHASE_ERROR_MAX_COUNT (6)
 
+/* Value returned by calcMasterLocalClockRateDifference() to indicate
+   detection of negative time jump in follow_up message */
+#define NEGATIVE_TIME_JUMP 0.0
 
 /**
  * @brief Provides the clock quality abstraction.

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1009,6 +1009,18 @@ void PTPMessageFollowUp::processMessage( EtherPort *port )
 	if( correction > 0 )
 	  TIMESTAMP_ADD_NS( preciseOriginTimestamp, correction );
 	else TIMESTAMP_SUB_NS( preciseOriginTimestamp, -correction );
+
+	local_clock_adjustment =
+	  port->getClock()->
+	  calcMasterLocalClockRateDifference
+	  ( preciseOriginTimestamp, sync_arrival );
+
+	if( local_clock_adjustment == NEGATIVE_TIME_JUMP )
+	{
+		GPTP_LOG_VERBOSE("Received Follow Up but preciseOrigintimestamp indicates negative time jump");
+		goto done;
+	}
+
 	scalar_offset  = TIMESTAMP_TO_NS( sync_arrival );
 	scalar_offset -= TIMESTAMP_TO_NS( preciseOriginTimestamp );
 
@@ -1017,6 +1029,7 @@ void PTPMessageFollowUp::processMessage( EtherPort *port )
 		 delay);
 	GPTP_LOG_VERBOSE
 		("FollowUp Scalar = %lld", scalar_offset);
+
 
 	/* Otherwise synchronize clock with approximate time from Sync message */
 	uint32_t local_clock, nominal_clock_rate;
@@ -1037,11 +1050,6 @@ void PTPMessageFollowUp::processMessage( EtherPort *port )
 		 "Device Time: %u,%u",
 	     system_time.seconds_ls, system_time.nanoseconds,
 	     device_time.seconds_ls, device_time.nanoseconds);
-
-	local_clock_adjustment =
-	  port->getClock()->
-	  calcMasterLocalClockRateDifference
-	  ( preciseOriginTimestamp, sync_arrival );
 
 	/*Update information on local status structure.*/
 	scaledLastGmFreqChange = (int32_t)((1.0/local_clock_adjustment -1.0) * (1ULL << 41));


### PR DESCRIPTION
This change checks if time in follow_up messages is monotonic
and will discard “wrong” sync/follow_up to prevent calculating
incorrect values (ratio etc.). It was observed for some bridges
and for some cases, that such situation might happens (bridge issue)
and could lead to huge time instability, especially when syntonization
functionality is activated.