### PR TITLE
libigb: improve inter-process synchronization

### DIFF
--- a/lib/igb/igb_internal.h
+++ b/lib/igb/igb_internal.h
@@ -158,7 +158,7 @@ struct rx_ring {
 struct adapter {
 	struct e1000_hw hw;
 
-	sem_t *memlock;
+	pthread_mutex_t *memlock;
 
 	int ldev; /* file descriptor to igb */
 
@@ -185,6 +185,7 @@ struct adapter {
 	struct nettime_compare compare;
 	struct hwtstamp_ctrl hwtstamp;
 #endif
+	int active;
 };
 
 /*


### PR DESCRIPTION
libigb used a posix named semaphore to protect concurrent accesses from
multiple processes. But since the posix semaphore cannot be automatically
released on process termination, if some process holding the semaphore
terminates without releasing it, other processes cannot acquire the semaphore
afterward. This could potentially cause a denial of service condition.
This patch replaces the posix named semaphore by a posix mutex.

In addition this patch adds a flag which prevents access to device after
calling igb_detach. Since igb_detach frees up associated resources, other
thread in multi-thread application should not access device once some thread
started resource clean-up by calling igb_detach. Otherwise invalid access to
freed memories could happen.