### PR TITLE
gPTP: remove 'const' that breaks syntonization on linux

### DIFF
--- a/daemons/gptp/common/ieee1588.hpp
+++ b/daemons/gptp/common/ieee1588.hpp
@@ -498,8 +498,7 @@ public:
 	 * @param  frequency_offset Frequency offset
 	 * @return false
 	 */
-	virtual bool HWTimestamper_adjclockrate
-	( float frequency_offset ) const
+	virtual bool HWTimestamper_adjclockrate( float frequency_offset )
 	{ return false; }
 
 	/**

--- a/daemons/gptp/common/ieee1588clock.cpp
+++ b/daemons/gptp/common/ieee1588clock.cpp
@@ -436,7 +436,7 @@ void IEEE1588Clock::setMasterOffset
 			if (port->getTestMode()) {
 				GPTP_LOG_STATUS("Adjust clock rate ppm:%f", _ppm);
 			}
-			if( !_timestamper->HWTimestamper_adjclockrate( _ppm )) {
+			if( !port->adjustClockRate( _ppm )) {
 				GPTP_LOG_ERROR( "Failed to adjust clock rate" );
 			}
 		}


### PR DESCRIPTION
With 'const' proper HWTimestamper_adjclockrate was not executed
and "Failed to adjust clock rate" error was flooding (with -S option).