### PR TITLE
gPTP: change HWTimestamper_adjclockrate into const function

### DIFF
--- a/daemons/gptp/common/ether_port.cpp
+++ b/daemons/gptp/common/ether_port.cpp
@@ -581,23 +581,15 @@ bool EtherPort::_processEvent( Event e )
 
 			if ( tx_succeed )
 			{
+				Timestamp sync_timestamp = sync->getTimestamp();
+
 				GPTP_LOG_VERBOSE("Successful Sync timestamp");
 				GPTP_LOG_VERBOSE("Seconds: %u",
 						 sync_timestamp.seconds_ls);
 				GPTP_LOG_VERBOSE("Nanoseconds: %u",
 						 sync_timestamp.nanoseconds);
-			} else {
-				GPTP_LOG_ERROR
-					("*** Unsuccessful Sync timestamp");
-			}
 
-			PTPMessageFollowUp *follow_up;
-			if ( tx_succeed )
-			{
-				Timestamp sync_timestamp =
-					sync->getTimestamp();
-				follow_up =
-					new PTPMessageFollowUp(this);
+				PTPMessageFollowUp *follow_up = new PTPMessageFollowUp(this);
 				PortIdentity dest_id;
 				getPortIdentity(dest_id);
 
@@ -609,9 +601,10 @@ bool EtherPort::_processEvent( Event e )
 				follow_up->sendPort(this, NULL);
 				delete follow_up;
 			} else {
+				GPTP_LOG_ERROR
+					("*** Unsuccessful Sync timestamp");
 			}
 			delete sync;
-
 		}
 		break;
 	case FAULT_DETECTED:

--- a/daemons/gptp/common/ieee1588clock.cpp
+++ b/daemons/gptp/common/ieee1588clock.cpp
@@ -334,7 +334,7 @@ FrequencyRatio IEEE1588Clock::calcMasterLocalClockRateDifference( Timestamp mast
 	}
 
 	if( master_time_ns < prev_master_time_ns ) {
-		GPTP_LOG_ERROR("Negative time jump detected - inter_master_time: %lld, inter_sync_time: %lld, icorrect ppt_offset: %Lf",
+		GPTP_LOG_ERROR("Negative time jump detected - inter_master_time: %lld, inter_sync_time: %lld, incorrect ppt_offset: %Lf",
 					   inter_master_time, inter_sync_time, ppt_offset);
 		_master_local_freq_offset_init = false;
 
@@ -428,10 +428,10 @@ void IEEE1588Clock::setMasterOffset
 
 		if( _ppm < LOWER_FREQ_LIMIT ) _ppm = LOWER_FREQ_LIMIT;
 		if( _ppm > UPPER_FREQ_LIMIT ) _ppm = UPPER_FREQ_LIMIT;
-		if (port->getTestMode()) {
+		if ( port->getTestMode() ) {
 			GPTP_LOG_STATUS("Adjust clock rate ppm:%f", _ppm);
 		}
-		if( !port->adjustClockRate( _ppm )) {
+		if( !port->adjustClockRate( _ppm ) ) {
 			GPTP_LOG_ERROR( "Failed to adjust clock rate" );
 		}
 	}

--- a/daemons/gptp/linux/src/linux_hal_generic.cpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.cpp
@@ -208,7 +208,7 @@ LinuxTimestamperGeneric::LinuxTimestamperGeneric() {
 	sd = -1;
 }
 
-bool LinuxTimestamperGeneric::Adjust( void *tmx ) {
+bool LinuxTimestamperGeneric::Adjust( void *tmx ) const {
 	if( syscall(__NR_clock_adjtime, _private->clockid, tmx ) != 0 ) {
 		GPTP_LOG_ERROR("Failed to adjust PTP clock rate");
 		return false;

--- a/daemons/gptp/linux/src/linux_hal_generic.hpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.hpp
@@ -91,7 +91,7 @@ public:
 	 * the struct timex
 	 * @return TRUE if ok, FALSE if error.
 	 */
-	bool Adjust( void *tmx );
+	bool Adjust( void *tmx ) const;
 
 	/**
 	 * @brief  Initializes the Hardware timestamp interface
@@ -186,7 +186,7 @@ public:
 	 * @param  freq_offset Frequency adjustment
 	 * @return TRUE in case of sucess, FALSE if error.
 	 */
-	virtual bool HWTimestamper_adjclockrate( float freq_offset );
+	virtual bool HWTimestamper_adjclockrate( float freq_offset ) const;
 
 #ifdef WITH_IGBLIB
 	bool HWTimestamper_PPS_start( );

--- a/daemons/gptp/linux/src/linux_hal_generic_adj.cpp
+++ b/daemons/gptp/linux/src/linux_hal_generic_adj.cpp
@@ -94,7 +94,7 @@ bool LinuxTimestamperGeneric::HWTimestamper_adjclockphase( int64_t phase_adjust 
 	return ret;
 }
 	
-bool LinuxTimestamperGeneric::HWTimestamper_adjclockrate( float freq_offset ) {
+bool LinuxTimestamperGeneric::HWTimestamper_adjclockrate( float freq_offset ) const {
 	struct timex tx;
 	tx.modes = ADJ_FREQUENCY;
 	tx.freq  = long(freq_offset) << 16;


### PR DESCRIPTION
Proper HWTimestamper_adjclockrate was not executed due to
const-overloading issue and "Failed to adjust clock rate"
error was flooding (broken syntonization). Additional fix
for compilation error ('sync_timestamp' not declared) when
verbosity logs are activated.