### PR TITLE
gPTP: fix SIOCGIFNAME ioctl failure

### DIFF
--- a/daemons/gptp/linux/src/linux_hal_common.cpp
+++ b/daemons/gptp/linux/src/linux_hal_common.cpp
@@ -250,7 +250,7 @@ static void x_initLinkUpStatus( EtherPort *pPort, int ifindex )
 		close(inetSocket);
 		return;
 	}
-	if (device.ifr_flags && IFF_RUNNING) {
+	if (device.ifr_flags & IFF_RUNNING) {
 		GPTP_LOG_DEBUG("Interface %s is up", device.ifr_name);
 		pPort->setLinkUpState(true);
 	} //linkUp == false by default


### PR DESCRIPTION
Use an INET socket rather than a NETLINK socket to get link speed
with ioctl() since NETLINK sockets do not support ioctl().