### PR TITLE
mrpctl: read all pending messages

### DIFF
--- a/daemons/mrpd/mrpctl.c
+++ b/daemons/mrpd/mrpctl.c
@@ -261,9 +261,10 @@ int main(int argc, char *argv[])
 		if (-1 == rc) goto out;
 
 		/* yield replies */
-		rc = mrpdclient_recv(mrpd_sock, process_ctl_msg);
-		if (-1 == rc) goto out;
-
+		do {
+			rc = mrpdclient_recv(mrpd_sock, process_ctl_msg);
+			if (-1 == rc) goto out;
+		while (rc >=0);
 		sleep(1);
 	} while (1);
 

--- a/daemons/mrpd/mrpctl.c
+++ b/daemons/mrpd/mrpctl.c
@@ -264,7 +264,7 @@ int main(int argc, char *argv[])
 		do {
 			rc = mrpdclient_recv(mrpd_sock, process_ctl_msg);
 			if (-1 == rc) goto out;
-		while (rc >=0);
+		} while (rc >=0);
 		sleep(1);
 	} while (1);
 


### PR DESCRIPTION
In each iteration mrpctl sends 3 messages but receives just one - this makes a lot of receive messages left unread in the socket and introduces a big delay in status updates.
This patch reads out all available messages during each cycle.

Signed-off-by: Andreas Pape <apape@de.adit-jv.com>