### PR TITLE
Fix for gPTP interval init on ARM platforms

### DIFF
--- a/daemons/gptp/common/common_port.hpp
+++ b/daemons/gptp/common/common_port.hpp
@@ -230,16 +230,16 @@ typedef struct {
 	bool linkUp;
 
 	/* gPTP 10.2.4.4 */
-	char initialLogSyncInterval;
+	signed char initialLogSyncInterval;
 
 	/* gPTP 11.5.2.2 */
-	char initialLogPdelayReqInterval;
+	signed char initialLogPdelayReqInterval;
 
 	/* CDS 6.2.1.5 */
-	char operLogPdelayReqInterval;
+	signed char operLogPdelayReqInterval;
 
 	/* CDS 6.2.1.6 */
-	char operLogSyncInterval;
+	signed char operLogSyncInterval;
 
 	/* condition_factory OSConditionFactory instance */
 	OSConditionFactory * condition_factory;


### PR DESCRIPTION
PortInit_t used char fields to store signed sentinel values to
indicate that default values should be set by the port. This was
fine for Intel, which generally has a signed representation for
the char type, but the sentinel values were not recognized on ARM
platforms, where char is generally unsigned.

Changing the fields to explicitly be of signed char type resolves
the problem on ARM and keeps the same behavior on Intel.