### PR TITLE
Rest of fix for gPTP intervals on ARM

### DIFF
--- a/daemons/gptp/common/common_port.hpp
+++ b/daemons/gptp/common/common_port.hpp
@@ -314,9 +314,9 @@ private:
 	PortState port_state;
 	bool testMode;
 
-	char log_mean_sync_interval;
-	char log_mean_announce_interval;
-	char initialLogSyncInterval;
+	signed char log_mean_sync_interval;
+	signed char log_mean_announce_interval;
+	signed char initialLogSyncInterval;
 
 	/*Sync threshold*/
 	unsigned int sync_receipt_thresh;
@@ -1219,7 +1219,7 @@ public:
 	 * @brief  Gets the sync interval value
 	 * @return Sync Interval
 	 */
-	char getSyncInterval( void )
+	signed char getSyncInterval( void )
 	{
 		return log_mean_sync_interval;
 	}
@@ -1229,7 +1229,7 @@ public:
 	 * @param  val time interval
 	 * @return none
 	 */
-	void setSyncInterval( char val )
+	void setSyncInterval( signed char val )
 	{
 		log_mean_sync_interval = val;
 	}
@@ -1247,7 +1247,7 @@ public:
 	 * @brief  Sets the sync interval
 	 * @return none
 	 */
-	void setInitSyncInterval( char interval )
+	void setInitSyncInterval( signed char interval )
 	{
 		initialLogSyncInterval = interval;
 	}
@@ -1256,7 +1256,7 @@ public:
 	 * @brief  Gets the sync interval
 	 * @return sync interval
 	 */
-	char getInitSyncInterval( void )
+	signed char getInitSyncInterval( void )
 	{
 		return initialLogSyncInterval;
 	}
@@ -1265,7 +1265,7 @@ public:
 	 * @brief  Gets the announce interval
 	 * @return Announce interval
 	 */
-	char getAnnounceInterval( void ) {
+	signed char getAnnounceInterval( void ) {
 		return log_mean_announce_interval;
 	}
 
@@ -1274,7 +1274,7 @@ public:
 	 * @param  val time interval
 	 * @return none
 	 */
-	void setAnnounceInterval(char val) {
+	void setAnnounceInterval(signed char val) {
 		log_mean_announce_interval = val;
 	}
 	/**

--- a/daemons/gptp/common/ether_port.hpp
+++ b/daemons/gptp/common/ether_port.hpp
@@ -96,9 +96,9 @@ class EtherPort : public CommonPort
 	bool linkUp;
 
 	/* Port Configuration */
-	char log_mean_unicast_sync_interval;
-	char log_min_mean_delay_req_interval;
-	char log_min_mean_pdelay_req_interval;
+	signed char log_mean_unicast_sync_interval;
+	signed char log_min_mean_delay_req_interval;
+	signed char log_min_mean_pdelay_req_interval;
 
 	unsigned int duplicate_resp_counter;
 	uint16_t last_invalid_seqid;
@@ -107,9 +107,9 @@ class EtherPort : public CommonPort
 	// port_state : already defined as port_state
 	bool isGM;
 	// asCapable : already defined as asCapable
-	char operLogPdelayReqInterval;
-	char operLogSyncInterval;
-	char initialLogPdelayReqInterval;
+	signed char operLogPdelayReqInterval;
+	signed char operLogSyncInterval;
+	signed char initialLogPdelayReqInterval;
 	bool automotive_profile;
 
 	// Test Status variables
@@ -306,7 +306,7 @@ protected:
 	 * @brief  Gets the pDelay minimum interval
 	 * @return PDelay interval
 	 */
-	char getPDelayInterval(void) {
+	signed char getPDelayInterval(void) {
 		return log_min_mean_pdelay_req_interval;
 	}
 
@@ -315,7 +315,7 @@ protected:
 	 * @param  val time interval
 	 * @return none
 	 */
-	void setPDelayInterval(char val) {
+	void setPDelayInterval(signed char val) {
 		log_min_mean_pdelay_req_interval = val;
 	}
 


### PR DESCRIPTION
The previous fix correctly identified the problem but was incomplete--this
one has actually been verified to work. More `char` fields had to be changed
to `signed char` to avoid problems with negative numbers.