### PR TITLE
MAAP addresses reused, shaper daemon shutdown fix

### DIFF
--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -467,8 +467,18 @@ bool CommonPort::processStateChange( Event e )
 
 bool CommonPort::processSyncAnnounceTimeout( Event e )
 {
+	// We're Grandmaster, set grandmaster info to me
+	ClockIdentity clock_identity;
+	unsigned char priority1;
+	unsigned char priority2;
+	ClockQuality clock_quality;
+
+	Timestamp system_time;
+	Timestamp device_time;
+	uint32_t local_clock, nominal_clock_rate;
+
 	// Nothing to do
-	if( clock->getPriority1() != 255 )
+	if( clock->getPriority1() == 255 )
 		return true;
 
 	// Restart timer
@@ -487,57 +497,38 @@ bool CommonPort::processSyncAnnounceTimeout( Event e )
 			   1000000000.0)));
 	}
 
-	if ( getPortState() == PTP_INITIALIZING ||
-	     getPortState() == PTP_UNCALIBRATED ||
-	     getPortState() == PTP_SLAVE ||
-	     getPortState() == PTP_PRE_MASTER )
-	{
-		GPTP_LOG_STATUS(
-			"*** %s Timeout Expired - Becoming Master",
-			e == ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES ? "Announce" :
-			"Sync" );
-		{
-			// We're Grandmaster, set grandmaster info to me
-			ClockIdentity clock_identity;
-			unsigned char priority1;
-			unsigned char priority2;
-			ClockQuality clock_quality;
+	if( getPortState() == PTP_MASTER )
+		return true;
 
-			clock_identity = getClock()->getClockIdentity();
-			getClock()->setGrandmasterClockIdentity
-				( clock_identity );
-			priority1 = getClock()->getPriority1();
-			getClock()->setGrandmasterPriority1( priority1 );
-			priority2 = getClock()->getPriority2();
-			getClock()->setGrandmasterPriority2( priority2 );
-			clock_quality = getClock()->getClockQuality();
-			getClock()->setGrandmasterClockQuality
-				( clock_quality );
-		}
-		setPortState( PTP_MASTER );
-		Timestamp system_time;
-		Timestamp device_time;
+	GPTP_LOG_STATUS(
+		"*** %s Timeout Expired - Becoming Master",
+		e == ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES ? "Announce" :
+		"Sync" );
 
-		uint32_t local_clock, nominal_clock_rate;
+	clock_identity = getClock()->getClockIdentity();
+	getClock()->setGrandmasterClockIdentity( clock_identity );
+	priority1 = getClock()->getPriority1();
+	getClock()->setGrandmasterPriority1( priority1 );
+	priority2 = getClock()->getPriority2();
+	getClock()->setGrandmasterPriority2( priority2 );
+	clock_quality = getClock()->getClockQuality();
+	getClock()->setGrandmasterClockQuality( clock_quality );
 
-		getDeviceTime(system_time, device_time,
-			      local_clock, nominal_clock_rate);
+	setPortState( PTP_MASTER );
 
-		(void) clock->calcLocalSystemClockRateDifference
-			( device_time, system_time );
+	getDeviceTime( system_time, device_time,
+		       local_clock, nominal_clock_rate );
 
-		setQualifiedAnnounce( NULL );
+	(void) clock->calcLocalSystemClockRateDifference
+		( device_time, system_time );
 
-		// Add timers for Announce and Sync, this is as close to
-		// immediately as we get
-		if( clock->getPriority1() != 255)
-		{
-			clock->addEventTimerLocked
-				( this, SYNC_INTERVAL_TIMEOUT_EXPIRES,
-				  16000000 );
-		}
-		startAnnounce();
-	}
+	setQualifiedAnnounce( NULL );
+
+	clock->addEventTimerLocked
+		( this, SYNC_INTERVAL_TIMEOUT_EXPIRES,
+		  16000000 );
+
+	startAnnounce();
 
 	return true;
 }

--- a/daemons/gptp/common/common_port.hpp
+++ b/daemons/gptp/common/common_port.hpp
@@ -230,16 +230,16 @@ typedef struct {
 	bool linkUp;
 
 	/* gPTP 10.2.4.4 */
-	char initialLogSyncInterval;
+	signed char initialLogSyncInterval;
 
 	/* gPTP 11.5.2.2 */
-	char initialLogPdelayReqInterval;
+	signed char initialLogPdelayReqInterval;
 
 	/* CDS 6.2.1.5 */
-	char operLogPdelayReqInterval;
+	signed char operLogPdelayReqInterval;
 
 	/* CDS 6.2.1.6 */
-	char operLogSyncInterval;
+	signed char operLogSyncInterval;
 
 	/* condition_factory OSConditionFactory instance */
 	OSConditionFactory * condition_factory;
@@ -314,9 +314,9 @@ private:
 	PortState port_state;
 	bool testMode;
 
-	char log_mean_sync_interval;
-	char log_mean_announce_interval;
-	char initialLogSyncInterval;
+	signed char log_mean_sync_interval;
+	signed char log_mean_announce_interval;
+	signed char initialLogSyncInterval;
 
 	/*Sync threshold*/
 	unsigned int sync_receipt_thresh;
@@ -1219,7 +1219,7 @@ public:
 	 * @brief  Gets the sync interval value
 	 * @return Sync Interval
 	 */
-	char getSyncInterval( void )
+	signed char getSyncInterval( void )
 	{
 		return log_mean_sync_interval;
 	}
@@ -1229,7 +1229,7 @@ public:
 	 * @param  val time interval
 	 * @return none
 	 */
-	void setSyncInterval( char val )
+	void setSyncInterval( signed char val )
 	{
 		log_mean_sync_interval = val;
 	}
@@ -1247,7 +1247,7 @@ public:
 	 * @brief  Sets the sync interval
 	 * @return none
 	 */
-	void setInitSyncInterval( char interval )
+	void setInitSyncInterval( signed char interval )
 	{
 		initialLogSyncInterval = interval;
 	}
@@ -1256,7 +1256,7 @@ public:
 	 * @brief  Gets the sync interval
 	 * @return sync interval
 	 */
-	char getInitSyncInterval( void )
+	signed char getInitSyncInterval( void )
 	{
 		return initialLogSyncInterval;
 	}
@@ -1265,7 +1265,7 @@ public:
 	 * @brief  Gets the announce interval
 	 * @return Announce interval
 	 */
-	char getAnnounceInterval( void ) {
+	signed char getAnnounceInterval( void ) {
 		return log_mean_announce_interval;
 	}
 
@@ -1274,7 +1274,7 @@ public:
 	 * @param  val time interval
 	 * @return none
 	 */
-	void setAnnounceInterval(char val) {
+	void setAnnounceInterval(signed char val) {
 		log_mean_announce_interval = val;
 	}
 	/**

--- a/daemons/gptp/common/ether_port.hpp
+++ b/daemons/gptp/common/ether_port.hpp
@@ -96,9 +96,9 @@ class EtherPort : public CommonPort
 	bool linkUp;
 
 	/* Port Configuration */
-	char log_mean_unicast_sync_interval;
-	char log_min_mean_delay_req_interval;
-	char log_min_mean_pdelay_req_interval;
+	signed char log_mean_unicast_sync_interval;
+	signed char log_min_mean_delay_req_interval;
+	signed char log_min_mean_pdelay_req_interval;
 
 	unsigned int duplicate_resp_counter;
 	uint16_t last_invalid_seqid;
@@ -107,9 +107,9 @@ class EtherPort : public CommonPort
 	// port_state : already defined as port_state
 	bool isGM;
 	// asCapable : already defined as asCapable
-	char operLogPdelayReqInterval;
-	char operLogSyncInterval;
-	char initialLogPdelayReqInterval;
+	signed char operLogPdelayReqInterval;
+	signed char operLogSyncInterval;
+	signed char initialLogPdelayReqInterval;
 	bool automotive_profile;
 
 	// Test Status variables
@@ -306,7 +306,7 @@ protected:
 	 * @brief  Gets the pDelay minimum interval
 	 * @return PDelay interval
 	 */
-	char getPDelayInterval(void) {
+	signed char getPDelayInterval(void) {
 		return log_min_mean_pdelay_req_interval;
 	}
 
@@ -315,7 +315,7 @@ protected:
 	 * @param  val time interval
 	 * @return none
 	 */
-	void setPDelayInterval(char val) {
+	void setPDelayInterval(signed char val) {
 		log_min_mean_pdelay_req_interval = val;
 	}
 

--- a/daemons/mrpd/mrpctl.c
+++ b/daemons/mrpd/mrpctl.c
@@ -261,8 +261,10 @@ int main(int argc, char *argv[])
 		if (-1 == rc) goto out;
 
 		/* yield replies */
-		rc = mrpdclient_recv(mrpd_sock, process_ctl_msg);
-		if (-1 == rc) goto out;
+		do {
+			rc = mrpdclient_recv(mrpd_sock, process_ctl_msg);
+			if (-1 == rc) goto out;
+		} while (rc >=0);
 
 		sleep(1);
 	} while (1);

--- a/lib/avtp_pipeline/endpoint/openavb_endpoint.c
+++ b/lib/avtp_pipeline/endpoint/openavb_endpoint.c
@@ -479,7 +479,7 @@ int avbEndpointLoop(void)
 			break;
 		}
 
-		if (!openavbMaapInitialize(x_cfg.ifname, x_cfg.maapPort, maapRestartCallback)) {
+		if (!openavbMaapInitialize(x_cfg.ifname, x_cfg.maapPort, &(x_cfg.maap_preferred), maapRestartCallback)) {
 			AVB_LOG_ERROR("Failed to initialize MAAP");
 			openavbQmgrFinalize();
 			break;

--- a/lib/avtp_pipeline/maap/openavb_maap.h
+++ b/lib/avtp_pipeline/maap/openavb_maap.h
@@ -36,7 +36,7 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 typedef void (openavbMaapRestartCb_t)(void *handle, struct ether_addr *addr);
 
 // MAAP library lifecycle
-bool openavbMaapInitialize(const char *ifname, unsigned int maapPort, openavbMaapRestartCb_t* cbfn);
+bool openavbMaapInitialize(const char *ifname, unsigned int maapPort, struct ether_addr *maapPrefAddr, openavbMaapRestartCb_t* cbfn);
 void openavbMaapFinalize();
 
 bool openavbMaapDaemonAvailable(void);

--- a/lib/avtp_pipeline/platform/Linux/endpoint/openavb_endpoint_cfg.c
+++ b/lib/avtp_pipeline/platform/Linux/endpoint/openavb_endpoint_cfg.c
@@ -51,6 +51,16 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 #define MATCH(A, B)(strcasecmp((A), (B)) == 0)
 #define MATCH_FIRST(A, B)(strncasecmp((A), (B), strlen(B)) == 0)
 
+static bool parse_mac(const char *str, struct ether_addr *mac)
+{
+	memset(mac, 0, sizeof(struct ether_addr));
+	if (ether_aton_r(str, mac) != NULL)
+		return TRUE;
+
+	AVB_LOGF_ERROR("Failed to parse addr: %s", str);
+	return FALSE;
+}
+
 static void cfgValErr(const char *section, const char *name, const char *value)
 {
 	AVB_LOGF_ERROR("Invalid value: section=%s, name=%s, value=%s",
@@ -203,6 +213,22 @@ static int cfgCallback(void *user, const char *section, const char *name, const 
 			return 0;
 		}
 	}
+
+	// Special section to load saved settings.
+	else if (MATCH(section, "saved"))
+	{
+		if (MATCH(name, "maap_preferred"))
+		{
+			valOK = parse_mac(value, &(pCfg->maap_preferred));
+		}
+		else {
+			// unmatched item, fail
+			AVB_LOGF_ERROR("Unrecognized configuration item: section=%s, name=%s", section, name);
+			AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+			return 0;
+		}
+	}
+
 	else {
 		// unmatched item, fail
 		AVB_LOGF_ERROR("Unrecognized configuration item: section=%s, name=%s", section, name);
@@ -222,7 +248,7 @@ static int cfgCallback(void *user, const char *section, const char *name, const 
 
 // Parse ini file, and create config data
 //
-int openavbReadConfig(const char *ini_file, openavb_endpoint_cfg_t *pCfg)
+int openavbReadConfig(const char *ini_file, const char *save_ini_file, openavb_endpoint_cfg_t *pCfg)
 {
 	AVB_TRACE_ENTRY(AVB_TRACE_ENDPOINT);
 
@@ -233,13 +259,73 @@ int openavbReadConfig(const char *ini_file, openavb_endpoint_cfg_t *pCfg)
 	int result = ini_parse(ini_file, cfgCallback, pCfg);
 	if (result < 0) {
 		AVB_LOGF_ERROR("Couldn't parse INI file: %s", ini_file);
+		AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
 		return -1;
     }
 	if (result > 0) {
 		AVB_LOGF_ERROR("Error in INI file: %s, line %d", ini_file, result);
+		AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
 		return -1;
     }
 
+	result = ini_parse(save_ini_file, cfgCallback, pCfg);
+	if (result > 0) {
+		AVB_LOGF_ERROR("Error in INI file: %s, line %d", ini_file, result);
+		AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+		return -1;
+    }
+
+	AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+
+	// Yay, we did it.
+	return 0;
+}
+
+// Create ini file with information to save.
+//
+int openavbSaveConfig(const char *ini_file, const openavb_endpoint_cfg_t *pCfg)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_ENDPOINT);
+
+	FILE* file;
+
+	char *pvtFilename = strdup(ini_file);
+	if (!pvtFilename) {
+		AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+		return -1;
+	}
+
+	char *override = strchr(pvtFilename, ',');
+	if (override)
+		*override++ = '\0';
+
+	file = fopen(pvtFilename, "w");
+	if (!file) {
+		AVB_LOGF_WARNING("Error saving to INI file: %s", ini_file);
+		free (pvtFilename);
+		AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+		return -1;
+	}
+
+	if (fputs("[saved]\n", file) < 0) {
+		AVB_LOGF_ERROR("Error writing to INI file: %s", ini_file);
+		fclose(file);
+		free (pvtFilename);
+		AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+		return -1;
+	}
+	if (fprintf(file, "maap_preferred = " ETH_FORMAT "\n", ETH_OCTETS(pCfg->maap_preferred.ether_addr_octet)) < 0) {
+		AVB_LOGF_ERROR("Error writing to INI file: %s", ini_file);
+		fclose(file);
+		free (pvtFilename);
+		AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+		return -1;
+	}
+
+	fclose(file);
+	free (pvtFilename);
+
+	AVB_LOGF_DEBUG("Saved settings to INI file: %s", ini_file);
 	AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
 
 	// Yay, we did it.

--- a/lib/avtp_pipeline/platform/Linux/endpoint/openavb_endpoint_cfg.h
+++ b/lib/avtp_pipeline/platform/Linux/endpoint/openavb_endpoint_cfg.h
@@ -44,23 +44,28 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 #include "net/if.h"
 
 #define DEFAULT_INI_FILE "endpoint.ini"
+#define DEFAULT_SAVE_INI_FILE "endpoint_save.ini"
 
 typedef struct {
-	char 		ifname[IFNAMSIZ + 10]; // Include space for the socket type prefix (e.g. "simple:eth0")
-	U8			ifmac[ETH_ALEN];
-	char		*ptp_start_opts;
-	int			ifindex;
-	unsigned	link_kbit;
-	unsigned	nsr_kbit;
-	unsigned	mtu;
-	unsigned	fqtss_mode;
-	bool		noSrp;
-	unsigned	maapPort;
-	unsigned	shaperPort;
-	bool		bypassAsCapableCheck;
+	char				ifname[IFNAMSIZ + 10]; // Include space for the socket type prefix (e.g. "simple:eth0")
+	U8					ifmac[ETH_ALEN];
+	char				*ptp_start_opts;
+	int					ifindex;
+	unsigned			link_kbit;
+	unsigned			nsr_kbit;
+	unsigned			mtu;
+	unsigned			fqtss_mode;
+	bool				noSrp;
+	unsigned			maapPort;
+	unsigned			shaperPort;
+	bool				bypassAsCapableCheck;
+
+	// Information to be saved for future use.
+	struct ether_addr	maap_preferred; // Last assigned MAAP address.
 } openavb_endpoint_cfg_t;
 
-int openavbReadConfig(const char *inifile, openavb_endpoint_cfg_t *pCfg);
+int openavbReadConfig(const char *ini_file, const char *save_ini_file, openavb_endpoint_cfg_t *pCfg);
+int openavbSaveConfig(const char *save_ini_file, const openavb_endpoint_cfg_t *pCfg);
 void openavbUnconfigure(openavb_endpoint_cfg_t *pCfg);
 
 #endif // AVB_ENDPOINT_CONFIG_H

--- a/lib/avtp_pipeline/platform/Linux/endpoint/openavb_endpoint_osal.c
+++ b/lib/avtp_pipeline/platform/Linux/endpoint/openavb_endpoint_osal.c
@@ -72,7 +72,7 @@ bool startEndpoint(int mode, int ifindex, const char* ifname, unsigned mtu, unsi
 	x_cfg.link_kbit = link_kbit;
 	x_cfg.nsr_kbit = nsr_kbit;
 
-	openavbReadConfig(DEFAULT_INI_FILE, &x_cfg);
+	openavbReadConfig(DEFAULT_INI_FILE, DEFAULT_SAVE_INI_FILE, &x_cfg);
 
 	if_info_t ifinfo;
 	if (ifname && openavbCheckInterface(ifname, &ifinfo)) {

--- a/lib/avtp_pipeline/platform/Linux/tl/openavb_tl_osal.c
+++ b/lib/avtp_pipeline/platform/Linux/tl/openavb_tl_osal.c
@@ -63,7 +63,7 @@ typedef struct {
 	openavb_tl_cfg_name_value_t *pNVCfg;
 } parse_ini_data_t;
 
-bool parse_mac(const char *str, cfg_mac_t *mac)
+static bool parse_mac(const char *str, cfg_mac_t *mac)
 {
 	memset(&mac->buffer, 0, sizeof(struct ether_addr));
 

--- a/lib/avtp_pipeline/tl/openavb_tl.c
+++ b/lib/avtp_pipeline/tl/openavb_tl.c
@@ -515,11 +515,14 @@ EXTERN_DLL_EXPORT bool openavbTLRun(tl_handle_t handle)
 		if (pTLState->cfg.role == AVB_ROLE_TALKER) {
 			THREAD_CREATE_TALKER();
 
-			THREAD_SET_RT_PRIORITY(pTLState->TLThread, pTLState->cfg.thread_rt_priority);
-			THREAD_PIN(pTLState->TLThread, pTLState->cfg.thread_affinity);
+			if (pTLState->cfg.thread_rt_priority != 0) { THREAD_SET_RT_PRIORITY(pTLState->TLThread, pTLState->cfg.thread_rt_priority); }
+			if (pTLState->cfg.thread_affinity != 0xFFFFFFFF) { THREAD_PIN(pTLState->TLThread, pTLState->cfg.thread_affinity); }
 		}
 		else if (pTLState->cfg.role == AVB_ROLE_LISTENER) {
 			THREAD_CREATE_LISTENER();
+
+			if (pTLState->cfg.thread_rt_priority != 0) { THREAD_SET_RT_PRIORITY(pTLState->TLThread, pTLState->cfg.thread_rt_priority); }
+			if (pTLState->cfg.thread_affinity != 0xFFFFFFFF) { THREAD_PIN(pTLState->TLThread, pTLState->cfg.thread_affinity); }
 		}
 
 		retVal = TRUE;


### PR DESCRIPTION
Thread priority and affinity supported for Listeners
Added initial support to save useful information to the endpoint_save.ini file for re-use the next time the application is run.  By design, the ini file is only updated as needed.  Currently saving the assigned MAAP address so that the same address can be requested again.
If the shaper daemon receives a Ctrl-C signal, it shuts down as if the user called the quit ("-q") command, rather than just aborting.  This allows for cleanup of the current configuration to occur.
White space fixes.