### PR TITLE
AAF Updates

### DIFF
--- a/lib/avtp_pipeline/map_aaf_audio/openavb_map_aaf_audio_pub.h
+++ b/lib/avtp_pipeline/map_aaf_audio/openavb_map_aaf_audio_pub.h
@@ -32,7 +32,7 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 /*
  * HEADER SUMMARY : AVTP Audio Format mapping module public interface
  *
- * AAF is defined in IEEE 1722a (still in draft as of Feb 2015).
+ * AAF (AVTP Audio Format) is defined in IEEE 1722-2016 Clause 7.
  *
  * map_nv_tx_rate must be set in the .ini file.
  */

--- a/lib/avtp_pipeline/map_uncmp_audio/openavb_map_uncmp_audio.c
+++ b/lib/avtp_pipeline/map_uncmp_audio/openavb_map_uncmp_audio.c
@@ -724,7 +724,6 @@ extern DLL_EXPORT bool openavbMapUncmpAudioInitialize(media_q_t *pMediaQ, openav
 		}
 
 		pvt_data_t *pPvtData = pMediaQ->pPvtMapInfo;
-		media_q_pub_map_uncmp_audio_info_t *pPubMapInfo = pMediaQ->pPubMapInfo;
 
 		pMapCB->map_cfg_cb = openavbMapUncmpAudioCfgCB;
 		pMapCB->map_subtype_cb = openavbMapUncmpAudioSubtypeCB;
@@ -745,8 +744,6 @@ extern DLL_EXPORT bool openavbMapUncmpAudioInitialize(media_q_t *pMediaQ, openav
 		pPvtData->maxTransitUsec = inMaxTransitUsec;
 		pPvtData->DBC = 0;
 		pPvtData->audioMcr = AVB_MCR_NONE;
-
-		pPubMapInfo->sparseMode = TS_SPARSE_MODE_UNSPEC;
 
 		openavbMediaQSetMaxLatency(pMediaQ, inMaxTransitUsec);
 	}

--- a/lib/avtp_pipeline/map_uncmp_audio/openavb_map_uncmp_audio_pub.h
+++ b/lib/avtp_pipeline/map_uncmp_audio/openavb_map_uncmp_audio_pub.h
@@ -60,19 +60,6 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
  */
 #define MapUncmpAudioMediaQDataFormat "UncmpAudio"
 
-/** Defines AAF timestamping mode:
- * - TS_SPARSE_MODE_DISABLED - timestamp is valid in every avtp packet
- * - TS_SPARSE_MODE_ENABLED - timestamp is valid in every 8th avtp packet
- */
-typedef enum {
-	/// Unspecified
-	TS_SPARSE_MODE_UNSPEC		= 0,
-	/// Disabled
-	TS_SPARSE_MODE_DISABLED		= 1,
-	/// Enabled
-	TS_SPARSE_MODE_ENABLED		= 8
-} avb_audio_sparse_mode_t;
-
 /** Contains detailed information of the audio format.
  * \note Interface module has to set during the RX and TX init callbacks:
  * - audioRate,
@@ -80,7 +67,6 @@ typedef enum {
  * - audioBitDepth,
  * - audioEndian,
  * - audioChannels,
- * - sparseMode.
  * \note The rest of fields mapping module will set these during the RX and TX
  * init callbacks. The interface module can use these during the RX and TX
  * callbacks.
@@ -96,8 +82,6 @@ typedef struct {
 	avb_audio_endian_t audioEndian;
 	/// Number of channels
 	avb_audio_channels_t audioChannels;
-	/// Sparse timestamping mode
-	avb_audio_sparse_mode_t sparseMode;
 
 	// The mapping module will set these during the RX and TX init callbacks
 	// The interface module can use these during the RX and TX callbacks.

--- a/lib/avtp_pipeline/map_uncmp_audio/uncmp_audio_map.md
+++ b/lib/avtp_pipeline/map_uncmp_audio/uncmp_audio_map.md
@@ -41,8 +41,6 @@ audioType          |How the data is organized - what is the data type of       \
                     samples @ref avb_audio_type_t
 audioBitDepth      |What is the bit depth of audio @ref avb_audio_bit_depth_t
 audioChannels      |How many channels there are @ref avb_audio_channels_t
-sparseMode         |Timestamping mode @ref avb_audio_sparse_mode_t \
-                    (not used in this mapping module)
 
 Below you can find description of how to set up those variables in interfaces
 * [wav file interface](@ref wav_file_intf)

--- a/lib/avtp_pipeline/platform/Linux/intf_alsa/aaf_file_talker.ini
+++ b/lib/avtp_pipeline/platform/Linux/intf_alsa/aaf_file_talker.ini
@@ -127,3 +127,7 @@ intf_fn = openavbIntfWavFileInitialize
 
 # intf_nv_file_name: The fully qualified file name.
 intf_nv_file_name = test.wav
+
+# AAF is defined to be big-endian.
+intf_nv_audio_endian = big
+

--- a/lib/avtp_pipeline/platform/Linux/intf_alsa/aaf_listener.ini
+++ b/lib/avtp_pipeline/platform/Linux/intf_alsa/aaf_listener.ini
@@ -115,15 +115,14 @@ intf_fn = openavbIntfAlsaInitialize
 intf_nv_device_name = default
 
 # intf_nv_audio_rate: Valid values that are supported by AAF are:
-#  8000, 16000, 32000, 44100, 48000, 88200, 96000, 176400 and 192000
+#  8000, 16000, 24000, 32000, 44100, 48000, 88200, 96000, 176400 and 192000
 intf_nv_audio_rate = 48000
 
 # intf_nv_audio_bit_depth: Valid values that are supported by AAF are:
-#  8, 16, 32
+#  16, 24, 32
 intf_nv_audio_bit_depth = 32
 
-# intf_nv_audio_channels: Valid values that are supported by AAF are:
-#  1 - 8
+# intf_nv_audio_channels
 intf_nv_audio_channels = 2
 
 # intf_nv_allow_resampling: 0 = disable software resampling. 1 = allow software resampling. Default is disable.
@@ -137,3 +136,7 @@ intf_nv_start_threshold_periods = 3
 # This influence ALSA's period_time and period_size parameters and the result value should be the nearest possible.
 # Initial playback latency is equal intf_nv_start_threshold_periods * intf_nv_period_time. If not set internal defaults are used.
 # intf_nv_period_time = 31250
+
+# AAF is defined to be big-endian.
+intf_nv_audio_endian = big
+

--- a/lib/avtp_pipeline/platform/Linux/intf_alsa/aaf_listener_auto.ini
+++ b/lib/avtp_pipeline/platform/Linux/intf_alsa/aaf_listener_auto.ini
@@ -111,15 +111,14 @@ intf_fn = openavbIntfAlsaInitialize
 intf_nv_device_name = default
 
 # intf_nv_audio_rate: Valid values that are supported by AAF are:
-#  8000, 16000, 32000, 44100, 48000, 88200, 96000, 176400 and 192000
+#  8000, 16000, 24000, 32000, 44100, 48000, 88200, 96000, 176400 and 192000
 intf_nv_audio_rate = 48000
 
 # intf_nv_audio_bit_depth: Valid values that are supported by AAF are:
-#  8, 16, 32
+#  16, 24, 32
 intf_nv_audio_bit_depth = 16
 
-# intf_nv_audio_channels: Valid values that are supported by AAF are:
-#  1 - 8
+# intf_nv_audio_channels
 intf_nv_audio_channels = 2
 
 # intf_nv_allow_resampling: 0 = disable software resampling. 1 = allow software resampling. Default is disable.
@@ -133,3 +132,7 @@ intf_nv_start_threshold_periods = 3
 # This influence ALSA's period_time and period_size parameters and the result value should be the nearest possible.
 # Initial playback latency is equal intf_nv_start_threshold_periods * intf_nv_period_time. If not set internal defaults are used.
 # intf_nv_period_time = 31250
+
+# AAF is defined to be big-endian.
+intf_nv_audio_endian = big
+

--- a/lib/avtp_pipeline/platform/Linux/intf_alsa/aaf_talker.ini
+++ b/lib/avtp_pipeline/platform/Linux/intf_alsa/aaf_talker.ini
@@ -152,17 +152,19 @@ intf_fn = openavbIntfAlsaInitialize
 intf_nv_device_name = default
 
 # intf_nv_audio_rate: Valid values that are supported by AAF are:
-#  8000, 16000, 32000, 44100, 48000, 88200, 96000, 176400 and 192000
+#  8000, 16000, 24000, 32000, 44100, 48000, 88200, 96000, 176400 and 192000
 intf_nv_audio_rate = 48000
 
 # intf_nv_audio_bit_depth: Valid values that are supported by AAF are:
-#  8, 16, 32
+#  16, 24, 32
 intf_nv_audio_bit_depth = 32
 
-# intf_nv_audio_channels: Valid values that are supported by AAF are:
-#  1 - 8
+# intf_nv_audio_channels
 intf_nv_audio_channels = 2
 
 # intf_nv_allow_resampling: 0 = disable software resampling. 1 = allow software resampling. Default is disable.
 intf_nv_allow_resampling = 1
+
+# AAF is defined to be big-endian.
+intf_nv_audio_endian = big
 

--- a/lib/avtp_pipeline/platform/Linux/intf_wav_file/openavb_intf_wav_file.c
+++ b/lib/avtp_pipeline/platform/Linux/intf_wav_file/openavb_intf_wav_file.c
@@ -450,16 +450,6 @@ bool openavbIntfWavFileTxCB(media_q_t *pMediaQ)
 			return FALSE;
 		}
 
-		//put current wall time into tail item used by AAF maping module
-		if ((pPubMapUncmpAudioInfo->sparseMode != TS_SPARSE_MODE_UNSPEC)) {
-			pMediaQItem = openavbMediaQTailLock(pMediaQ, TRUE);
-			if ((pMediaQItem) && (pPvtData->intervalCounter % pPubMapUncmpAudioInfo->sparseMode == 0)) {
-				openavbAvtpTimeSetToWallTime(pMediaQItem->pAvtpTime);
-			}
-			openavbMediaQTailUnlock(pMediaQ);
-			pMediaQItem = NULL;
-		}
-
 		if (pPvtData->intervalCounter++ % pPubMapUncmpAudioInfo->packingFactor != 0)
 			return TRUE;
 


### PR DESCRIPTION
Changes to the AAF support to make it compatible with IEEE 1722-2016 Clause 7.
Listener will adjust to use the sparse mode and integer size of the Talker.
Talker sparse mode support moved from intf (ALSA and WAV) to map_aaf.