### PR TITLE
SyncIntervalTimer lock changed to trylock

### DIFF
--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -311,7 +311,7 @@ void CommonPort::stopSyncReceiptTimer( void )
 void CommonPort::startSyncIntervalTimer
 ( long long unsigned int waitTime )
 {
-	syncIntervalTimerLock->lock();
+	if( syncIntervalTimerLock->trylock() == oslock_fail ) return;
 	clock->deleteEventTimerLocked(this, SYNC_INTERVAL_TIMEOUT_EXPIRES);
 	clock->addEventTimerLocked
 		(this, SYNC_INTERVAL_TIMEOUT_EXPIRES, waitTime);


### PR DESCRIPTION
The change is required to prevent a deadlock that occurs
when PTPMessageSignalling is received in the middle of
processEvent SYNC_INTERVAL_TIMEOUT_EXPIRES

Signed-off-by: Michal Wasko <michal.wasko@intel.com>