### PR TITLE
PTP Port role restore on LinkUp event

### DIFF
--- a/daemons/gptp/common/ether_port.cpp
+++ b/daemons/gptp/common/ether_port.cpp
@@ -396,11 +396,20 @@ bool EtherPort::_processEvent( Event e )
 	case LINKUP:
 		haltPdelay(false);
 		startPDelay();
+
 		if (automotive_profile) {
 			GPTP_LOG_EXCEPTION("LINKUP");
 		}
 		else {
 			GPTP_LOG_STATUS("LINKUP");
+		}
+
+		if( clock->getPriority1() == 255 || port_state == PTP_SLAVE ) {
+			becomeSlave( true );
+		} else if( port_state == PTP_MASTER ) {
+			becomeMaster( true );
+		} else {
+			startAnnounce();
 		}
 
 		if (automotive_profile) {

--- a/daemons/gptp/common/ether_port.cpp
+++ b/daemons/gptp/common/ether_port.cpp
@@ -396,7 +396,6 @@ bool EtherPort::_processEvent( Event e )
 	case LINKUP:
 		haltPdelay(false);
 		startPDelay();
-
 		if (automotive_profile) {
 			GPTP_LOG_EXCEPTION("LINKUP");
 		}


### PR DESCRIPTION
PTP Master/Slave port role assignment has
been added to LinkUp event handling to avoid
situation when the gPTP daemon is unable to
re-sync after link lost situation.

Signed-off-by: Michal Wasko <michal.wasko@intel.com>