### PR TITLE
PTP Port role restore on Link Up event

### DIFF
--- a/daemons/gptp/common/ether_port.cpp
+++ b/daemons/gptp/common/ether_port.cpp
@@ -403,6 +403,14 @@ bool EtherPort::_processEvent( Event e )
 			GPTP_LOG_STATUS("LINKUP");
 		}
 
+		if( clock->getPriority1() == 255 || getPortState() == PTP_SLAVE ) {
+			becomeSlave( true );
+		} else if( getPortState() == PTP_MASTER ) {
+			becomeMaster( true );
+		} else {
+			startAnnounce();
+		}
+
 		if (automotive_profile) {
 			setAsCapable( true );
 


### PR DESCRIPTION
PTP Master/Slave port role restore added to
Link Up event processing to guarantee proper
gPTP daemon re-sync after Link loss situation
due to partner platform reboot. The PTP role
restore is especially important for the case
when platforms are connected directly with
ethernet cable - no switch in between.

Signed-off-by: Michal Wasko <michal.wasko@intel.com>