### PR TITLE
gPTP Announce interval timer restart fixed

### DIFF
--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -597,13 +597,9 @@ bool CommonPort::processEvent( Event e )
 
 	case ANNOUNCE_INTERVAL_TIMEOUT_EXPIRES:
 		GPTP_LOG_DEBUG("ANNOUNCE_INTERVAL_TIMEOUT_EXPIRES occured");
-		if( !asCapable )
-		{
-			ret = true;
-			break;
-		}
 
 		// Send an announce message
+		if ( asCapable)
 		{
 			PTPMessageAnnounce *annc =
 				new PTPMessageAnnounce(this);


### PR DESCRIPTION
The change fix a problem of gPTP daemon synchronization
in non-automotive profile when daemon is  not ready at
start (asCapable=false) - for example due to link down.
In above situation with previous implementation the
announce interval timer will not restart on
ANNOUNCE_INTERVAL_TIMEOUT_EXPIRES event.

Signed-off-by: Michal Wasko <michal.wasko@intel.com>