### PR TITLE
listen for announces on init and linkup

### DIFF
--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -550,7 +550,7 @@ bool CommonPort::processEvent( Event e )
 
 		// If port has been configured as master or slave, run media
 		// specific configuration. If it hasn't been configured
-		// start announce message time
+		// start listening for announce messages
 		if( clock->getPriority1() == 255 ||
 		    port_state == PTP_SLAVE )
 		{
@@ -562,7 +562,8 @@ bool CommonPort::processEvent( Event e )
 		}
 		else
 		{
-			startAnnounce();
+			clock->addEventTimerLocked(this, ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES,
+				ANNOUNCE_RECEIPT_TIMEOUT_MULTIPLIER * pow(2.0, getAnnounceInterval()) * 1000000000.0);
 		}
 
 		// Do any media specific initialization

--- a/daemons/gptp/common/ether_port.cpp
+++ b/daemons/gptp/common/ether_port.cpp
@@ -408,7 +408,8 @@ bool EtherPort::_processEvent( Event e )
 		} else if( getPortState() == PTP_MASTER ) {
 			becomeMaster( true );
 		} else {
-			startAnnounce();
+			clock->addEventTimerLocked(this, ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES,
+				ANNOUNCE_RECEIPT_TIMEOUT_MULTIPLIER * pow(2.0, getAnnounceInterval()) * 1000000000.0);
 		}
 
 		if (automotive_profile) {


### PR DESCRIPTION
Currently, if starting two instances of daemon_cl, they do not connect to each other because neither listens for announce messages. This changes them from sending announces to listening. They then start announcing after an ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES event.