### PR TITLE
AAF 24 kHz support, cleanup

### DIFF
--- a/lib/avtp_pipeline/include/openavb_audio_pub.h
+++ b/lib/avtp_pipeline/include/openavb_audio_pub.h
@@ -2,16 +2,16 @@
 Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
 Copyright (c) 2016-2017, Harman International Industries, Incorporated
 All rights reserved.
- 
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
- 
+
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
- 
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,10 +22,10 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
-Attributions: The inih library portion of the source code is licensed from 
-Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt. 
-Complete license and copyright information can be found at 
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
 https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
@@ -51,6 +51,8 @@ typedef enum {
 	AVB_AUDIO_RATE_16KHZ 		= 16000,
 	/// 22050
 	AVB_AUDIO_RATE_22_05KHZ		= 22050,
+	/// 24000
+	AVB_AUDIO_RATE_24KHZ		= 24000,
 	/// 32000
 	AVB_AUDIO_RATE_32KHZ		= 32000,
 	/// 44100

--- a/lib/avtp_pipeline/map_aaf_audio/openavb_map_aaf_audio.c
+++ b/lib/avtp_pipeline/map_aaf_audio/openavb_map_aaf_audio.c
@@ -82,6 +82,7 @@ typedef enum {
 	AAF_RATE_96K,
 	AAF_RATE_176K4,
 	AAF_RATE_192K,
+	AAF_RATE_24K,
 } aaf_nominal_sample_rate_t;
 
 typedef enum {
@@ -173,6 +174,9 @@ static void x_calculateSizes(media_q_t *pMediaQ)
 				break;
 			case AVB_AUDIO_RATE_16KHZ:
 				pPvtData->aaf_rate = AAF_RATE_16K;
+				break;
+			case AVB_AUDIO_RATE_24KHZ:
+				pPvtData->aaf_rate = AAF_RATE_24K;
 				break;
 			case AVB_AUDIO_RATE_32KHZ:
 				pPvtData->aaf_rate = AAF_RATE_32K;
@@ -481,15 +485,15 @@ tx_cb_ret_t openavbMapAVTPAudioTxCB(media_q_t *pMediaQ, U8 *pData, U32 *dataLen)
 		return TX_CB_RET_PACKET_NOT_READY;
 	}
 
+	U32 tmp32;
+	U8 *pHdrV0 = pData;
+	U32 *pHdr = (U32 *)(pData + AVTP_V0_HEADER_SIZE);
+	U8  *pPayload = pData + TOTAL_HEADER_SIZE;
+
 	U32 bytesProcessed = 0;
 	while (bytesProcessed < bytesNeeded) {
 		pMediaQItem = openavbMediaQTailLock(pMediaQ, TRUE);
 		if (pMediaQItem && pMediaQItem->pPubData && pMediaQItem->dataLen > 0) {
-
-			U32 tmp32;
-			U8 *pHdrV0 = pData;
-			U32 *pHdr = (U32 *)(pData + AVTP_V0_HEADER_SIZE);
-			U8  *pPayload = pData + TOTAL_HEADER_SIZE;
 
 			// timestamp set in the interface module, here just validate
 			// In sparse mode, the timestamp valid flag should be set every eighth AAF AVPTDU.
@@ -858,8 +862,8 @@ void openavbMapAVTPAudioEndCB(media_q_t *pMediaQ)
 
 void openavbMapAVTPAudioGenEndCB(media_q_t *pMediaQ)
 {
-	AVB_TRACE_ENTRY(AVB_TRACE_INTF);
-	AVB_TRACE_EXIT(AVB_TRACE_INTF);
+	AVB_TRACE_ENTRY(AVB_TRACE_MAP);
+	AVB_TRACE_EXIT(AVB_TRACE_MAP);
 }
 
 // Initialization entry point into the mapping module. Will need to be included in the .ini file.


### PR DESCRIPTION
Added the missing 24 kHz rate to the list of supported rates.  (See  IEEE 1722-2016 Table 11)
Fix for case where audio payload is from two different media queue items (just in case).
Trace fix to use AVB_TRACE_MAP rather than AVB_TRACE_INTF.