### PR TITLE
Network interface string length consistency

### DIFF
--- a/lib/avtp_pipeline/endpoint/openavb_endpoint_server.c
+++ b/lib/avtp_pipeline/endpoint/openavb_endpoint_server.c
@@ -138,7 +138,7 @@ void openavbEptSrvrNotifyTlkrOfSrpCb(int h,
 	memset(&msgBuf, 0, OPENAVB_ENDPOINT_MSG_LEN);
 	msgBuf.type = OPENAVB_ENDPOINT_TALKER_CALLBACK;
 	memcpy(&(msgBuf.streamID), streamID, sizeof(AVBStreamID_t));
-	strncpy(msgBuf.params.talkerCallback.ifname, ifname, IFNAMSIZ - 1);
+	strncpy(msgBuf.params.talkerCallback.ifname, ifname, sizeof(msgBuf.params.talkerCallback.ifname) - 1);
 	memcpy(msgBuf.params.talkerCallback.destAddr, destAddr, ETH_ALEN);
 	msgBuf.params.talkerCallback.lsnrDecl = lsnrDecl;
 	msgBuf.params.talkerCallback.srClass = srClass;
@@ -174,7 +174,7 @@ void openavbEptSrvrNotifyLstnrOfSrpCb(int h,
 	memset(&msgBuf, 0, OPENAVB_ENDPOINT_MSG_LEN);
 	msgBuf.type = OPENAVB_ENDPOINT_LISTENER_CALLBACK;
 	memcpy(&(msgBuf.streamID), streamID, sizeof(AVBStreamID_t));
-	strncpy(msgBuf.params.listenerCallback.ifname, ifname, IFNAMSIZ - 1);
+	strncpy(msgBuf.params.listenerCallback.ifname, ifname, sizeof(msgBuf.params.listenerCallback.ifname) - 1);
 	if (destAddr)
 		memcpy(msgBuf.params.listenerCallback.destAddr, destAddr, ETH_ALEN);
 	msgBuf.params.listenerCallback.tlkrDecl = tlkrDecl;

--- a/lib/avtp_pipeline/platform/Linux/avdecc/openavb_avdecc_cfg.c
+++ b/lib/avtp_pipeline/platform/Linux/avdecc/openavb_avdecc_cfg.c
@@ -79,7 +79,7 @@ static int cfgCallback(void *user, const char *section, const char *name, const 
 		{
 			if_info_t ifinfo;
 			if (openavbCheckInterface(value, &ifinfo)) {
-				strncpy(pCfg->ifname, value, IFNAMSIZ - 1);
+				strncpy(pCfg->ifname, value, sizeof(pCfg->ifname) - 1);
 				memcpy(pCfg->ifmac, &ifinfo.mac, ETH_ALEN);
 				valOK = TRUE;
 			}

--- a/lib/avtp_pipeline/platform/Linux/endpoint/openavb_endpoint_cfg.c
+++ b/lib/avtp_pipeline/platform/Linux/endpoint/openavb_endpoint_cfg.c
@@ -2,16 +2,16 @@
 Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
 Copyright (c) 2016-2017, Harman International Industries, Incorporated
 All rights reserved.
- 
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
- 
+
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
- 
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,10 +22,10 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
-Attributions: The inih library portion of the source code is licensed from 
-Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt. 
-Complete license and copyright information can be found at 
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
 https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
@@ -76,9 +76,9 @@ static int cfgCallback(void *user, const char *section, const char *name, const 
 		AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
 		return 0;
 	}
-	
+
 	openavb_endpoint_cfg_t *pCfg = (openavb_endpoint_cfg_t*)user;
-	
+
 	AVB_LOGF_DEBUG("name=[%s] value=[%s]", name, value);
 
 	bool valOK = FALSE;
@@ -90,7 +90,7 @@ static int cfgCallback(void *user, const char *section, const char *name, const 
 		{
 			if_info_t ifinfo;
 			if (openavbCheckInterface(value, &ifinfo)) {
-				strncpy(pCfg->ifname, value, IFNAMSIZ - 1);
+				strncpy(pCfg->ifname, value, sizeof(pCfg->ifname) - 1);
 				memcpy(pCfg->ifmac, &ifinfo.mac, ETH_ALEN);
 				pCfg->ifindex = ifinfo.index;
 				pCfg->mtu = ifinfo.mtu;

--- a/lib/avtp_pipeline/platform/Linux/rawsock/simple_rawsock.c
+++ b/lib/avtp_pipeline/platform/Linux/rawsock/simple_rawsock.c
@@ -55,7 +55,7 @@ bool simpleAvbCheckInterface(const char *ifname, if_info_t *info)
 	memset(info, 0, sizeof(if_info_t));
 
 	AVB_LOGF_DEBUG("ifname=%s", ifname);
-	strncpy(info->name, ifname, IFNAMSIZ - 1);
+	strncpy(info->name, ifname, sizeof(info->name) - 1);
 
 	// open a throw-away socket - used for our ioctls
 	int sk = socket(AF_INET, SOCK_STREAM, 0);

--- a/lib/avtp_pipeline/platform/Linux/tl/openavb_tl_osal.c
+++ b/lib/avtp_pipeline/platform/Linux/tl/openavb_tl_osal.c
@@ -2,16 +2,16 @@
 Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
 Copyright (c) 2016-2017, Harman International Industries, Incorporated
 All rights reserved.
- 
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
- 
+
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
- 
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,10 +22,10 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
-Attributions: The inih library portion of the source code is licensed from 
-Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt. 
-Complete license and copyright information can be found at 
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
 https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
@@ -317,7 +317,7 @@ static int openavbTLCfgCallback(void *user, const char *tlSection, const char *n
 		}
 	}
 	else if (MATCH(name, "ifname")) {
-		strncpy(pCfg->ifname, value, IFNAMSIZ - 1);
+		strncpy(pCfg->ifname, value, sizeof(pCfg->ifname) - 1);
 		valOK = TRUE;
 	}
 	else if (MATCH(name, "vlan_id")) {

--- a/lib/avtp_pipeline/qmgr/openavb_qmgr.c
+++ b/lib/avtp_pipeline/qmgr/openavb_qmgr.c
@@ -2,16 +2,16 @@
 Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
 Copyright (c) 2016-2017, Harman International Industries, Incorporated
 All rights reserved.
- 
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
- 
+
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
- 
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,10 +22,10 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
-Attributions: The inih library portion of the source code is licensed from 
-Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt. 
-Complete license and copyright information can be found at 
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
 https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
@@ -275,7 +275,7 @@ bool openavbQmgrInitialize(int mode, int ifindex, const char* ifname, unsigned m
 
 		// Save the configuration
 		if (ifname)
-			strncpy(qdisc_data.ifname, ifname, IFNAMSIZ - 1);
+			strncpy(qdisc_data.ifname, ifname, sizeof(qdisc_data.ifname) - 1);
 		qdisc_data.ifindex = ifindex;
 		qdisc_data.linkKbit = link_kbit;
 		qdisc_data.linkMTU = mtu;

--- a/lib/avtp_pipeline/tl/openavb_listener_endpoint.c
+++ b/lib/avtp_pipeline/tl/openavb_listener_endpoint.c
@@ -2,16 +2,16 @@
 Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
 Copyright (c) 2016-2017, Harman International Industries, Incorporated
 All rights reserved.
- 
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
- 
+
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
- 
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,10 +22,10 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
-Attributions: The inih library portion of the source code is licensed from 
-Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt. 
-Complete license and copyright information can be found at 
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
 https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
@@ -91,9 +91,9 @@ void openavbEptClntNotifyLstnrOfSrpCb(int endpointHandle,
 		if (rc) {
 			// Save data provided by endpoint/SRP
 			if (!pCfg->ifname[0]) {
-				strncpy(pListenerData->ifname, ifname, IFNAMSIZ);
+				strncpy(pListenerData->ifname, ifname, sizeof(pListenerData->ifname) - 1);
 			} else {
-				strncpy(pListenerData->ifname, pCfg->ifname, IFNAMSIZ);
+				strncpy(pListenerData->ifname, pCfg->ifname, sizeof(pListenerData->ifname) - 1);
 			}
 			memcpy(&pListenerData->streamID, streamID, sizeof(AVBStreamID_t));
 			if (memcmp(destAddr, emptyMAC, ETH_ALEN) != 0) {

--- a/lib/avtp_pipeline/tl/openavb_listener_no_endpoint.c
+++ b/lib/avtp_pipeline/tl/openavb_listener_no_endpoint.c
@@ -2,16 +2,16 @@
 Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
 Copyright (c) 2016-2017, Harman International Industries, Incorporated
 All rights reserved.
- 
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
- 
+
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
- 
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,10 +22,10 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
-Attributions: The inih library portion of the source code is licensed from 
-Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt. 
-Complete license and copyright information can be found at 
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
 https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
@@ -52,7 +52,7 @@ bool openavbTLRunListenerInit(int hnd, AVBStreamID_t *streamID)
 	openavb_tl_cfg_t *pCfg = &pTLState->cfg;
 	listener_data_t *pListenerData = pTLState->pPvtListenerData;
 
-	strncpy(pListenerData->ifname, pCfg->ifname, IFNAMSIZ);
+	strncpy(pListenerData->ifname, pCfg->ifname, sizeof(pListenerData->ifname) - 1);
 	memcpy(&pListenerData->streamID.addr, &pCfg->stream_addr.mac->ether_addr_octet, ETH_ALEN);
 	pListenerData->streamID.uniqueID = pCfg->stream_uid;
 	memcpy(&pListenerData->destAddr, &pCfg->dest_addr.mac->ether_addr_octet, ETH_ALEN);
@@ -62,7 +62,7 @@ bool openavbTLRunListenerInit(int hnd, AVBStreamID_t *streamID)
 	AVB_LOGF_INFO("Dest Addr: "ETH_FORMAT, ETH_OCTETS(pListenerData->destAddr));
 	AVB_LOGF_INFO("Starting stream: "STREAMID_FORMAT, STREAMID_ARGS(streamID));
 	listenerStartStream(pTLState);
-	
+
 	return TRUE;
 }
 

--- a/lib/avtp_pipeline/tl/openavb_talker_endpoint.c
+++ b/lib/avtp_pipeline/tl/openavb_talker_endpoint.c
@@ -90,9 +90,9 @@ void openavbEptClntNotifyTlkrOfSrpCb(int                      endpointHandle,
 
 			// Save the data provided by endpoint/SRP
 			if (!pCfg->ifname[0]) {
-				strncpy(pTalkerData->ifname, ifname, IFNAMSIZ);
+				strncpy(pTalkerData->ifname, ifname, sizeof(pTalkerData->ifname) - 1);
 			} else {
-				strncpy(pTalkerData->ifname, pCfg->ifname, IFNAMSIZ);
+				strncpy(pTalkerData->ifname, pCfg->ifname, sizeof(pTalkerData->ifname) - 1);
 			}
 			memcpy(&pTalkerData->streamID, streamID, sizeof(AVBStreamID_t));
 			memcpy(&pTalkerData->destAddr, destAddr, ETH_ALEN);
@@ -109,9 +109,9 @@ void openavbEptClntNotifyTlkrOfSrpCb(int                      endpointHandle,
 		else if (lsnrDecl == openavbSrp_LDSt_Stream_Info) {
 			// Stream information is available does NOT mean listener is ready. Stream not started yet.
 			if (!pCfg->ifname[0]) {
-				strncpy(pTalkerData->ifname, ifname, IFNAMSIZ);
+				strncpy(pTalkerData->ifname, ifname, sizeof(pTalkerData->ifname) - 1);
 			} else {
-				strncpy(pTalkerData->ifname, pCfg->ifname, IFNAMSIZ);
+				strncpy(pTalkerData->ifname, pCfg->ifname, sizeof(pTalkerData->ifname) - 1);
 			}
 			memcpy(&pTalkerData->streamID, streamID, sizeof(AVBStreamID_t));
 			memcpy(&pTalkerData->destAddr, destAddr, ETH_ALEN);

--- a/lib/avtp_pipeline/tl/openavb_talker_no_endpoint.c
+++ b/lib/avtp_pipeline/tl/openavb_talker_no_endpoint.c
@@ -62,11 +62,10 @@ bool openavbTLRunTalkerInit(tl_state_t *pTLState)
 	talker_data_t *pTalkerData = pTLState->pPvtTalkerData;
 	//avtp_stream_t *pStream = (avtp_stream_t *)(pTalkerData->avtpHandle);
 
-	strncpy(pTalkerData->ifname, pCfg->ifname, IFNAMSIZ);
+	strncpy(pTalkerData->ifname, pCfg->ifname, sizeof(pTalkerData->ifname) - 1);
 
 	// CORE_TODO: It would be good to have some parts of endpoint moved into non-endpoint general code to handle some the stream
 	// configuration values.
-	// strncpy(pTalkerData->ifname, pCfg->ifname, IFNAMSIZ);
 	if (pCfg->stream_addr.mac) {
 		memcpy(pTalkerData->streamID.addr, pCfg->stream_addr.mac, ETH_ALEN);
 	}else {

--- a/lib/avtp_pipeline/tl/openavb_tl_pub.h
+++ b/lib/avtp_pipeline/tl/openavb_tl_pub.h
@@ -74,7 +74,9 @@ typedef enum {
 
 
 /// Maximum size of interface name
-#define IFNAMSIZE 16
+#ifndef IFNAMSIZ
+#define IFNAMSIZ 16
+#endif
 
 /// Maximum size of the friendly name
 #define FRIENDLY_NAME_SIZE 64
@@ -139,7 +141,7 @@ typedef struct {
 	/// Is the interface module blocking in the TX CB.
 	bool tx_blocking_in_intf;
 	/// Network interface name. Not used on all platforms.
-	char ifname[IFNAMSIZE];
+	char ifname[IFNAMSIZ + 10]; // Include space for the socket type prefix (e.g. "simple:eth0")
 	/// VLAN ID
 	U16 vlan_id;
 	/// When set incoming packets will trigger a signal to the stream task to wakeup.


### PR DESCRIPTION
More updates so that network interfaces include length for the rawsock type
prefix, and so the strncpy() commands use the extra length.
Also includes removal of some trailing whitespace.