### PR TITLE
Added logging support

### DIFF
--- a/lib/avtp_pipeline/platform/Linux/avb_avdecc/openavb_avdecc.c
+++ b/lib/avtp_pipeline/platform/Linux/avb_avdecc/openavb_avdecc.c
@@ -77,6 +77,7 @@ void openavbAvdeccHostUsage(char *programName)
 		"\n"
 		"Usage: %s [options] file...\n"
 		"  -I val     Use given (val) interface globally, can be overriden by giving the ifname= option to the config line.\n"
+		"  -l val     Filename of the log file to use.  If not specified, results will be logged to stderr.\n"
 		"\n"
 		"Examples:\n"
 		"  %s talker.ini\n"
@@ -98,6 +99,7 @@ int main(int argc, char *argv[])
 
 	char *programName;
 	char *optIfnameGlobal = NULL;
+	char *optLogFileName = NULL;
 
 	programName = strrchr(argv[0], '/');
 	programName = programName ? programName + 1 : argv[0];
@@ -110,11 +112,14 @@ int main(int argc, char *argv[])
 	// Process command line
 	bool optDone = FALSE;
 	while (!optDone) {
-		int opt = getopt(argc, argv, "hI:");
+		int opt = getopt(argc, argv, "hI:l:");
 		if (opt != EOF) {
 			switch (opt) {
 				case 'I':
 					optIfnameGlobal = strdup(optarg);
+					break;
+				case 'l':
+					optLogFileName = strdup(optarg);
 					break;
 				case 'h':
 				default:
@@ -130,7 +135,7 @@ int main(int argc, char *argv[])
 	int iniIdx = optind;
 	int tlCount = argc - iniIdx;
 
-	if (!osalAvdeccInitialize(optIfnameGlobal, (const char **) (argv + iniIdx), tlCount)) {
+	if (!osalAvdeccInitialize(optLogFileName, optIfnameGlobal, (const char **) (argv + iniIdx), tlCount)) {
 		osalAvdeccFinalize();
 		exit(-1);
 	}
@@ -172,6 +177,11 @@ int main(int argc, char *argv[])
 	}
 
 	osalAvdeccFinalize();
+
+	if (optLogFileName) {
+		free(optLogFileName);
+		optLogFileName = NULL;
+	}
 
 	AVB_TRACE_EXIT(AVB_TRACE_HOST);
 	exit(0);

--- a/lib/avtp_pipeline/platform/Linux/avb_host/openavb_harness.c
+++ b/lib/avtp_pipeline/platform/Linux/avb_host/openavb_harness.c
@@ -2,16 +2,16 @@
 Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
 Copyright (c) 2016-2017, Harman International Industries, Incorporated
 All rights reserved.
- 
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
- 
+
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
- 
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,10 +22,10 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
-Attributions: The inih library portion of the source code is licensed from 
-Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt. 
-Complete license and copyright information can be found at 
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
 https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
@@ -122,6 +122,7 @@ void openavbTlHarnessUsage(char *programName)
 		"  -s val     Stream count. Starts 'val' number of streams for each configuration file. stream_uid will be overriden.\n"
 		"  -d val     Last byte of destination address from static pool. Full address will be 91:e0:f0:00:fe:val.\n"
 		"  -I val     Use given (val) interface globally, can be overriden by giving the ifname= option to the config line.\n"
+		"  -l val     Filename of the log file to use.  If not specified, results will be logged to stderr.\n"
 		"\n"
 		"Examples:\n"
 		"  %s talker.ini\n"
@@ -172,6 +173,7 @@ int main(int argc, char *argv[])
 	bool optDestAddrSet = FALSE;
 	U8 destAddr[ETH_ALEN] = {0x91, 0xe0, 0xf0, 0x00, 0xfe, 0x00};
 	char *optIfnameGlobal = NULL;
+	char *optLogFileName = NULL;
 
 	// Talker listener vars
 	int iniIdx = 0;
@@ -229,7 +231,7 @@ int main(int argc, char *argv[])
 
 	bool optDone = FALSE;
 	while (!optDone) {
-		int opt = getopt(argc, argv, "a:his:d:I:");
+		int opt = getopt(argc, argv, "a:his:d:I:l:");
 		if (opt != EOF) {
 			switch (opt) {
 				case 'a':
@@ -249,6 +251,9 @@ int main(int argc, char *argv[])
 				case 'I':
 					optIfnameGlobal = strdup(optarg);
 					break;
+				case 'l':
+					optLogFileName = strdup(optarg);
+					break;
 				case '?':
 				default:
 					openavbTlHarnessUsage(programName);
@@ -260,7 +265,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	osalAVBInitialize(optIfnameGlobal);
+	osalAVBInitialize(optLogFileName, optIfnameGlobal);
 
 	// Setup the talker listener counts and lists
 	iniIdx = optind;
@@ -552,6 +557,11 @@ int main(int argc, char *argv[])
 	if (optStreamAddr) {
 		free(optStreamAddr);
 		optStreamAddr = NULL;
+	}
+
+	if (optLogFileName) {
+		free(optLogFileName);
+		optLogFileName = NULL;
 	}
 
 #ifdef AVB_FEATURE_GSTREAMER

--- a/lib/avtp_pipeline/platform/Linux/avb_host/openavb_host.c
+++ b/lib/avtp_pipeline/platform/Linux/avb_host/openavb_host.c
@@ -2,16 +2,16 @@
 Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
 Copyright (c) 2016-2017, Harman International Industries, Incorporated
 All rights reserved.
- 
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
- 
+
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
- 
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,10 +22,10 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
-Attributions: The inih library portion of the source code is licensed from 
-Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt. 
-Complete license and copyright information can be found at 
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
 https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
@@ -111,6 +111,7 @@ void openavbTlHostUsage(char *programName)
 		"\n"
 		"Usage: %s [options] file...\n"
 		"  -I val     Use given (val) interface globally, can be overriden by giving the ifname= option to the config line.\n"
+		"  -l val     Filename of the log file to use.  If not specified, results will be logged to stderr.\n"
 		"\n"
 		"Examples:\n"
 		"  %s talker.ini\n"
@@ -135,6 +136,7 @@ int main(int argc, char *argv[])
 	int iniIdx = 0;
 	char *programName;
 	char *optIfnameGlobal = NULL;
+	char *optLogFileName = NULL;
 
 	programName = strrchr(argv[0], '/');
 	programName = programName ? programName + 1 : argv[0];
@@ -150,11 +152,14 @@ int main(int argc, char *argv[])
 	// Process command line
 	bool optDone = FALSE;
 	while (!optDone) {
-		int opt = getopt(argc, argv, "hI:");
+		int opt = getopt(argc, argv, "hI:l:");
 		if (opt != EOF) {
 			switch (opt) {
 				case 'I':
 					optIfnameGlobal = strdup(optarg);
+					break;
+				case 'l':
+					optLogFileName = strdup(optarg);
 					break;
 				case 'h':
 				default:
@@ -167,7 +172,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	osalAVBInitialize(optIfnameGlobal);
+	osalAVBInitialize(optLogFileName, optIfnameGlobal);
 
 	iniIdx = optind;
 	U32 tlCount = argc - iniIdx;
@@ -299,6 +304,11 @@ int main(int argc, char *argv[])
 	}
 
 	openavbTLCleanup();
+
+	if (optLogFileName) {
+		free(optLogFileName);
+		optLogFileName = NULL;
+	}
 
 #ifdef AVB_FEATURE_GSTREAMER
 	// If we're supporting the interface modules which use GStreamer,

--- a/lib/avtp_pipeline/platform/Linux/openavb_osal.c
+++ b/lib/avtp_pipeline/platform/Linux/openavb_osal.c
@@ -2,16 +2,16 @@
 Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
 Copyright (c) 2016-2017, Harman International Industries, Incorporated
 All rights reserved.
- 
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
- 
+
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
- 
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,10 +22,10 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
-Attributions: The inih library portion of the source code is licensed from 
-Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt. 
-Complete license and copyright information can be found at 
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
 https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
@@ -37,9 +37,23 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 #include "openavb_pub.h"
 #include "openavb_log.h"
 
-extern DLL_EXPORT bool osalAVBInitialize(const char* ifname)
+static FILE *s_logfile = NULL;
+
+extern DLL_EXPORT bool osalAVBInitialize(const char* logfilename, const char* ifname)
 {
-	avbLogInit();
+	// Open the log file, if requested.
+	if (s_logfile) {
+		fclose(s_logfile);
+		s_logfile = NULL;
+	}
+	if (logfilename) {
+		s_logfile = fopen(logfilename, "w");
+		if (s_logfile == NULL) {
+			fprintf(stderr, "Error opening log file: %s\n", logfilename);
+		}
+	}
+
+	avbLogInitEx(s_logfile);
 	osalAVBTimeInit();
 	openavbQmgrInitialize(FQTSS_MODE_HW_CLASS, 0, ifname, 0, 0, 0);
 	return TRUE;
@@ -50,6 +64,13 @@ extern DLL_EXPORT bool osalAVBFinalize(void)
 	openavbQmgrFinalize();
 	osalAVBTimeClose();
 	avbLogExit();
+
+	// Done with the log file.
+	if (s_logfile) {
+		fclose(s_logfile);
+		s_logfile = NULL;
+	}
+
 	return TRUE;
 }
 

--- a/lib/avtp_pipeline/platform/Linux/openavb_osal_endpoint.c
+++ b/lib/avtp_pipeline/platform/Linux/openavb_osal_endpoint.c
@@ -2,16 +2,16 @@
 Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
 Copyright (c) 2016-2017, Harman International Industries, Incorporated
 All rights reserved.
- 
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
- 
+
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
- 
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,10 +22,10 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
-Attributions: The inih library portion of the source code is licensed from 
-Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt. 
-Complete license and copyright information can be found at 
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
 https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
@@ -38,9 +38,23 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 #include "openavb_pub.h"
 #include "openavb_log.h"
 
-extern DLL_EXPORT bool osalAVBInitialize(const char* ifname)
+static FILE *s_logfile = NULL;
+
+extern DLL_EXPORT bool osalAVBInitialize(const char* logfilename, const char* ifname)
 {
-	avbLogInit();
+	// Open the log file, if requested.
+	if (s_logfile) {
+		fclose(s_logfile);
+		s_logfile = NULL;
+	}
+	if (logfilename) {
+		s_logfile = fopen(logfilename, "w");
+		if (s_logfile == NULL) {
+			fprintf(stderr, "Error opening log file: %s\n", logfilename);
+		}
+	}
+
+	avbLogInitEx(s_logfile);
 	osalAVBTimeInit();
 	startEndpoint(FQTSS_MODE_HW_CLASS, 0, ifname, 0, 0, 0);
 	return TRUE;
@@ -51,6 +65,13 @@ extern DLL_EXPORT bool osalAVBFinalize(void)
 	stopEndpoint();
 	osalAVBTimeClose();
 	avbLogExit();
+
+	// Done with the log file.
+	if (s_logfile) {
+		fclose(s_logfile);
+		s_logfile = NULL;
+	}
+
 	return TRUE;
 }
 

--- a/lib/avtp_pipeline/platform/Linux/openavb_osal_pub.h
+++ b/lib/avtp_pipeline/platform/Linux/openavb_osal_pub.h
@@ -2,16 +2,16 @@
 Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
 Copyright (c) 2016-2017, Harman International Industries, Incorporated
 All rights reserved.
- 
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
- 
+
 1. Redistributions of source code must retain the above copyright notice, this
    list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
- 
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -22,10 +22,10 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
-Attributions: The inih library portion of the source code is licensed from 
-Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt. 
-Complete license and copyright information can be found at 
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
 https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
@@ -37,12 +37,12 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 
 #include "openavb_os_services_osal_pub.h"
 
-bool osalAVBInitialize(const char *ifname);
+bool osalAVBInitialize(const char* logfilename, const char *ifname);
 
 bool osalAVBFinalize(void);
 
 
-bool osalAvdeccInitialize(const char *ifname, const char **inifiles, int numfiles);
+bool osalAvdeccInitialize(const char* logfilename, const char *ifname, const char **inifiles, int numfiles);
 
 bool osalAvdeccFinalize(void);
 


### PR DESCRIPTION
AVTP Pipeline (openavb_host and openavb_harness) and AVDECC (openavb_avdecc)
have a new "-l" option to specify the filename of the log file to use.  If not
specified, then the behavior is unchanged, and stderr is used for logging.