### PR TITLE
RFC: Simplify timeval & timespec redefinition fix

### DIFF
--- a/daemons/gptp/linux/src/linux_hal_common.hpp
+++ b/daemons/gptp/linux/src/linux_hal_common.hpp
@@ -306,7 +306,7 @@ public:
 	OSLock * createLock( OSLockType type ) const
 	{
 		LinuxLock *lock = new LinuxLock();
-		if (lock->initialize(type) != oslock_ok) {
+		if (!lock->initialize(type)) {
 			delete lock;
 			lock = NULL;
 		}

--- a/daemons/gptp/linux/src/linux_hal_generic_adj.cpp
+++ b/daemons/gptp/linux/src/linux_hal_generic_adj.cpp
@@ -31,13 +31,8 @@
 
 ******************************************************************************/
 
-#include <linux/timex.h>
-// linux_hal_generic.hpp pulls in redefinition of struct timespec and timeval
-// Below are defines that prevent this:
-#define _TIME_H  1
-#define _STRUCT_TIMEVAL 1
-#define __timeval_defined 1
-#define __timespec_defined 1
+#include <sys/timex.h>
+#define ADJ_SETOFFSET 0x0100 // Missing from older header files
 #include <linux_hal_generic.hpp>
 #include <syscall.h>
 #include <math.h>


### PR DESCRIPTION
Eventually the additional #define can be removed, this is fixed in recent header files. I'm not sure if there are older header files that are even more broken that we want to support(?) I don't have very many installs to test against.