### PR TITLE
Add a note to the readme for the aPTP change fork.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,10 +120,10 @@ XMOS is a semiconductor company providing a reference design for AVB/TSN
 endpoints in pro audio and automotive. XMOS endpoint source code is open source 
 and available on Github - https://github.com/xcore/sw_avb
 
-apple vendor ptp profile
+Apple Vendor PTP Profile
 ------------------------
-Support for the apple vendor ptp profile can be found on this fork of the OpenAvnu code within the branch ArtAndLogic-aPTP-changes.
+Support for the Apple Vendor PTP Profile can be found on this fork of the OpenAvnu code within the branch ArtAndLogic-aPTP-changes.
 
 + https://github.com/rroussel/OpenAvnu/tree/ArtAndLogic-aPTP-changes 
 
-These changes allow interaction with apple proprietary ptp clocks. This implementation has been tested with the apple airplay SDK on a raspberry pi 3 running within a group of devices playing the same music stream.
+These changes allow interaction with Apple proprietary PTP clocks. This implementation has been tested with the Apple AirPlay SDK on a Raspberry Pi 3 running within a group of devices playing the same music stream.

--- a/README.rst
+++ b/README.rst
@@ -120,3 +120,10 @@ XMOS is a semiconductor company providing a reference design for AVB/TSN
 endpoints in pro audio and automotive. XMOS endpoint source code is open source 
 and available on Github - https://github.com/xcore/sw_avb
 
+apple vendor ptp profile
+------------------------
+Support for the apple vendor ptp profile can be found on this fork of the OpenAvnu code within the branch ArtAndLogic-aPTP-changes.
+
++ https://github.com/rroussel/OpenAvnu/tree/ArtAndLogic-aPTP-changes 
+
+These changes allow interaction with apple proprietary ptp clocks. This implementation has been tested with the apple airplay SDK on a raspberry pi 3 running within a group of devices playing the same music stream.


### PR DESCRIPTION
Per your request, I've altered the main readme with linking information to the fork containing the apple vendor ptp profile changes.