### PR TITLE
Daemon scripts cleanup

### DIFF
--- a/run_daemons.sh
+++ b/run_daemons.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # Start all daemons
 
-nic=$1
-
 if [ "$1" == "-h" ]; then
         echo "Usage: $0 <network interface>"
         echo "   eg: $0 eth1"
@@ -21,11 +19,11 @@ if [ "$1" == "" ]; then
         exit -1
 fi
 
+nic=$1
 echo "Starting daemons on "$nic
 
 groupadd ptp > /dev/null 2>&1
-daemons/gptp/linux/build/obj/daemon_cl $1 &
-daemons/mrpd/mrpd -mvs -i $1 &
-daemons/maap/linux/build/maap_daemon -i $1 -d /dev/null
+daemons/gptp/linux/build/obj/daemon_cl $nic &
+daemons/mrpd/mrpd -mvs -i $nic &
+daemons/maap/linux/build/maap_daemon -i $nic -d /dev/null
 daemons/shaper/shaper_daemon -d &
-

--- a/run_daemons.sh
+++ b/run_daemons.sh
@@ -6,28 +6,26 @@ nic=$1
 if [ "$1" == "-h" ]; then
         echo "Usage: $0 <network interface>"
         echo "   eg: $0 eth1"
+        echo ""
+        echo "If you are using IGB, call \"sudo ./run_igb.sh\" before running this script."
+        echo ""
         exit
 fi
 
 if [ "$1" == "" ]; then
-        nic="eth1" #edit as required
-        echo "Network interface not specified, assuming: $nic"
+        echo "Please enter network interface name as parameter. For example:"
+        echo "sudo $0 eth1"
+        echo ""
+        echo "If you are using IGB, call \"sudo ./run_igb.sh\" before running this script."
+        echo ""
+        exit -1
 fi
 
 echo "Starting daemons on "$nic
 
-#use false for silence
-if true; then
-        sudo rmmod igb
-        sudo insmod kmod/igb/igb_avb.ko
-        sudo groupadd ptp
-else
-        sudo rmmod igb > /dev/null 2>&1
-        sudo insmod kmod/igb/igb_avb.ko > /dev/null 2>&1
-        sudo groupadd ptp > /dev/null 2>&1
-fi
-
-sudo daemons/gptp/linux/build/obj/daemon_cl $nic &
-sudo daemons/mrpd/mrpd -mvs -i $nic &
-sudo daemons/maap/linux/maap_daemon -i $nic &
+groupadd ptp > /dev/null 2>&1
+daemons/gptp/linux/build/obj/daemon_cl $1 &
+daemons/mrpd/mrpd -mvs -i $1 &
+daemons/maap/linux/build/maap_daemon -i $1 -d /dev/null
+daemons/shaper/shaper_daemon -d &
 

--- a/stop_daemons.sh
+++ b/stop_daemons.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # Stop all daemons
 
-sudo killall maap_daemon
-sudo killall mrpd
-sudo killall daemon_cl
+killall shaper_daemon
+killall maap_daemon
+killall mrpd
+killall daemon_cl
 
 # possibly add rmmod igb_avb here
 


### PR DESCRIPTION
Added shaper_daemon to run_daemons.sh and stop_daemons.sh.
Fixed the path and parameters for maap_daemon.
IGB is now initialized separately, as the daemons can be run without it.
Don't assume the name of the NIC, and don't include "sudo" in the script, to
be consistent with the other run_*.sh scripts.