### PR TITLE
maap_daemon: segmentation fault fix while executing maap_daemon on aarch64 platform.

### DIFF
--- a/daemons/maap/linux/src/maap_log_linux.c
+++ b/daemons/maap/linux/src/maap_log_linux.c
@@ -27,6 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdarg.h>
 #include <string.h>
 #include <inttypes.h>
+#include <limits.h>
 
 #include "platform.h"
 #include "maap_log_queue.h"
@@ -74,7 +75,14 @@ extern void *loggingThreadFn(void *pv);
 THREAD_TYPE(loggingThread);
 THREAD_DEFINITON(loggingThread);
 
-#define THREAD_STACK_SIZE 									65536
+#if !defined(PTHREAD_STACK_MIN)
+#error "PTHREAD_STACK_MIN variable not defined"
+#elif (PTHREAD_STACK_MIN > 65536)
+#define THREAD_STACK_SIZE							PTHREAD_STACK_MIN
+#else
+#define THREAD_STACK_SIZE							65536
+#endif
+
 #define loggingThread_THREAD_STK_SIZE    					THREAD_STACK_SIZE
 
 static MUTEX_HANDLE_ALT(gLogMutex);


### PR DESCRIPTION
Problem description:
While executing maap_daemon on aarch64 platform, the segmentation fault is observed.

root@salvator-x:~# maap_daemon -i eth0
Enter "help" for a list of valid commands.
init
MAAP initialized:  0x91e0f0000000-0x91e0f000fdff (Size: 65024)
exit
[ 1946.874712] maap_daemon[2896]: unhandled level 2 translation fault (11) at 0x000000d0, esr 0x92000006
[ 1946.883977] pgd = ffff8006f2971000
[ 1946.887420] [000000d0] *pgd=0000000733e27003, *pud=0000000736a13003, *pmd=0000000000000000
[ 1946.895770]
[ 1946.897271] CPU: 1 PID: 2896 Comm: maap_daemon Tainted: G         C      4.9.54 #1
[ 1946.904875] Hardware name: Renesas Salvator-X board based on r8a7795 (DT)
[ 1946.911686] task: ffff8006fa593600 task.stack: ffff8006fa490000

----------------------------------------------------------------------
With debugging through code, it is found that:

Program received signal SIGSEGV, Segmentation fault.
0x0000ffffb7f98088 in pthread_join () from target:/lib64/libpthread.so.0
(gdb) bt
#0  0x0000ffffb7f98088 in pthread_join () from target:/lib64/libpthread.so.0
#1  0x0000000000405110 in maapLogExit ()
#2  0x0000000000403544 in act_as_server ()
#3  0x0000000000402408 in main ()
(gdb) 

----------------------------------------------------------------
THREAD_CREATE fails in pthread_attr_setstacksize() with error code 22 (EINVAL)
pthread_attr_setstacksize() --- >
check_stacksize_attr (size_t st)
{
  if (st >= PTHREAD_STACK_MIN)
    return 0;
  return EINVAL;
}

In case of other platforms (i686, arm), the value of PTHREAD_STACK_MIN is 16384.
But for aarch64 platform the value of PTHREAD_STACK_MIN is 131072.
Since thread itself has not created, but it is calling thread_join from maap_log_exit(), the program is throwing segmentation fault.

--------------------------------------------------------------------------
Resolution:

if PTHREAD_STACK_MIN is defined and greater than 64k, then assign THREAD_STACK_SIZE with value of PTHREAD_STACK_MIN.
