### PR TITLE
Fixing stale Tx timestamp fetch.

### DIFF
--- a/daemons/gptp/common/ptptypes.hpp
+++ b/daemons/gptp/common/ptptypes.hpp
@@ -43,6 +43,7 @@ typedef double FrequencyRatio;		/*!< Frequency Ratio */
 typedef long double FrequencyRatio;	/*!< Frequency Ratio */
 #endif
 
+#define ETHER_HDR_LEN (14)
 #define ETHER_ADDR_OCTETS	6		/*!< Number of octets in a link layer address*/
 #define IP_ADDR_OCTETS		4		/*!< Number of octets in a ip address*/
 #define PTP_ETHERTYPE 0x88F7		/*!< PTP ethertype */

--- a/daemons/gptp/linux/src/linux_hal_generic.cpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.cpp
@@ -30,7 +30,6 @@
   POSSIBILITY OF SUCH DAMAGE.
 
 ******************************************************************************/
-
 #include <linux_hal_generic.hpp>
 #include <linux_hal_generic_tsprivate.hpp>
 #include <platform.hpp>
@@ -288,7 +287,7 @@ int LinuxTimestamperGeneric::HWTimestamper_txtimestamp
 	struct sockaddr_ll remote;
 	struct iovec sgentry;
 	PTPMessageId reflectedMessageId;
-	uint8_t reflected_bytes[46];
+	uint8_t reflected_bytes[ETHER_HDR_LEN + PTP_COMMON_HDR_LENGTH];
 	uint8_t *gptpCommonHeader;
 	uint16_t sequenceId;
 	struct {
@@ -305,7 +304,7 @@ int LinuxTimestamperGeneric::HWTimestamper_txtimestamp
 	sgentry.iov_base = reflected_bytes;
 	sgentry.iov_len = sizeof(reflected_bytes);
 
-	gptpCommonHeader = reflected_bytes + 14;
+	gptpCommonHeader = reflected_bytes + ETHER_HDR_LEN;
 
 	memset( &remote, 0, sizeof(remote));
 	msg.msg_name = (caddr_t) &remote;
@@ -326,7 +325,7 @@ int LinuxTimestamperGeneric::HWTimestamper_txtimestamp
 	}
 	sequenceId = PLAT_ntohs(*((uint16_t*)(PTP_COMMON_HDR_SEQUENCE_ID(gptpCommonHeader))));
 	reflectedMessageId.setSequenceId(sequenceId);
-	reflectedMessageId.setMessageType((MessageType)(*gptpCommonHeader & 0xF));
+	reflectedMessageId.setMessageType((MessageType)(*PTP_COMMON_HDR_TRANSSPEC_MSGTYPE(gptpCommonHeader) & 0xF));
 	if (messageId != reflectedMessageId) {
 		GPTP_LOG_WARNING("Timestamp discarded due to wrong message id");
 		ret = GPTP_EC_EAGAIN;


### PR DESCRIPTION
It fixes daemon_cl behavior in the following situation.
1. Sent gPTP message.
2. Try to get the timestamp.
3. Repeat no. 2 until timeout occurs.
4. Timeout occurs, continue operation.
5. Timestamp comes (but it's not read).
6. Sent another gPTP message.
7. Try to get the timestamp.
8. Read the timestamp -> Timestamp from message no. 1 is being read.
9. Time synchronization fails due to the wrong Tx timestamp.

This fix discards stale Tx timestamps. It checks message type and sequence id of the reflected packet to see if it contains the timestamp for the frame being sent at the moment. In case it doesn't the timestamp is discarded.