### PR TITLE
Added wireless timestamper and port code

### DIFF
--- a/daemons/gptp/README.rst
+++ b/daemons/gptp/README.rst
@@ -94,6 +94,35 @@ To run from the command line:
 
 where xx-xx-xx-xx-xx-xx is the mac address of the local interface
 
+Windows Wireless Specific
++++++++++++++++++++++++++
+
+Additional Driver/Hardware Requirements:
+
+* Intel(R) 8260 Adapter
+
+* Intel(R) PROSet/Wireless Software
+
+
+The wireless software can be downloaded from:
+
+https://downloadcenter.intel.com/ (Search)
+
+Running the daemon:
+
+Currently, the driver only works with peer-to-peer wireless connections.
+The connection must be established prior to running the daemon.
+
+./gptp.exe -w <local hw device MAC> <local P2P MAC> <remove P2P MAC>
+
+Other limitations:
+
+Some versions of Windows(R) 10 do not allow WinPcap(R) to inject frames and
+the BMCA algorithm can't complete. The result is both peers assume the master
+role. To fix this, force one peer to be slave with the following command line:
+
+./gptp.exe -w -R 255 <local hw device MAC> <local P2P MAC> <remove P2P MAC>
+
 Other Available PTP Daemons
 ---------------------------
 There are a number of existing ptp daemon projects. Some of the other known 

--- a/daemons/gptp/common/avbts_clock.hpp
+++ b/daemons/gptp/common/avbts_clock.hpp
@@ -550,6 +550,15 @@ public:
     FrequencyRatio local_system_freq_offset, unsigned sync_count,
     unsigned pdelay_count, PortState port_state, bool asCapable );
 
+	/**
+	 * @brief  Get local:system frequency ratio
+	 * @return clock ratio
+	 */
+	FrequencyRatio getLocalSystemFreqOffset()
+	{
+		return _local_system_freq_offset;
+	}
+
   /**
    * @brief  Get the IEEE1588Clock identity value
    * @return clock identity

--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -204,6 +204,17 @@ public:
 };
 
 /**
+ * @brief  Builds PTP message from buffer
+ * @param  buf [in] byte buffer containing PTP message
+ * @param  size [in] length of buffer in bytes
+ * @param  remote [in] address from where message was received
+ * @param  port [in] port object that message was recieved on
+ * @return PTP message object
+ */
+PTPMessageCommon *buildPTPMessage
+( char *buf, int size, LinkLayerAddress *remote, CommonPort *port );
+
+/**
  * @brief Provides the PTPMessage common interface used during building of
  * PTP messages.
  */
@@ -373,10 +384,10 @@ protected:
 
 	/**
 	 * @brief  Generic interface for processing PTP message
-	 * @param  port IEEE1588 port
+	 * @param  port CommonPort object
 	 * @return void
 	 */
-	virtual void processMessage( EtherPort *port );
+	virtual void processMessage( CommonPort *port );
 
 	/**
 	 * @brief  Builds PTP common header
@@ -386,8 +397,7 @@ protected:
 	void buildCommonHeader(uint8_t * buf);
 
 	friend PTPMessageCommon *buildPTPMessage
-	( char *buf, int size, LinkLayerAddress * remote,
-	  EtherPort *port );
+	( char *buf, int size, LinkLayerAddress *remote, CommonPort *port );
 };
 
 /*Exact fit. No padding*/
@@ -589,12 +599,7 @@ class PTPMessageAnnounce:public PTPMessageCommon {
 		return ret;
 	}
 
-	/**
-	 * @brief  Processes PTP message
-	 * @param  port EtherPort
-	 * @return void
-	 */
-	void processMessage( EtherPort *port );
+	void processMessage( CommonPort *port );
 
 	/**
 	 * @brief  Assembles PTPMessageAnnounce message on the
@@ -608,8 +613,7 @@ class PTPMessageAnnounce:public PTPMessageCommon {
 	( CommonPort *port, PortIdentity *destIdentity);
 
 	friend PTPMessageCommon *buildPTPMessage
-	( char *buf, int size, LinkLayerAddress *remote,
-	  EtherPort *port );
+	( char *buf, int size, LinkLayerAddress *remote, CommonPort *port );
 };
 
 /**
@@ -632,12 +636,7 @@ class PTPMessageSync : public PTPMessageCommon {
 	 */
 	~PTPMessageSync();
 
-	/**
-	 * @brief  Processes PTP messages
-	 * @param  port [in] EtherPort
-	 * @return void
-	 */
-	void processMessage( EtherPort *port );
+	void processMessage( CommonPort *port );
 
 	/**
 	 * @brief  Gets origin timestamp value
@@ -659,8 +658,7 @@ class PTPMessageSync : public PTPMessageCommon {
 	(EtherPort *port, PortIdentity *destIdentity );
 
 	friend PTPMessageCommon *buildPTPMessage
-	( char *buf, int size, LinkLayerAddress * remote,
-	  EtherPort *port );
+	( char *buf, int size, LinkLayerAddress *remote, CommonPort *port );
 };
 
 /* Exact fit. No padding*/
@@ -866,7 +864,15 @@ public:
 	/**
 	 * @brief Builds the PTPMessageFollowUP object
 	 */
-	PTPMessageFollowUp( EtherPort *port );
+	PTPMessageFollowUp( CommonPort *port );
+
+	/**
+	 * @brief write followup message into buffer
+	 * @param port [in] associated CommonPort object
+	 * @param buf_ptr [out] buffer to write data to
+	 * @return number of bytes written to buffer
+	 */
+	size_t buildMessage(CommonPort *port, uint8_t *buf_ptr);
 
 	/**
 	 * @brief  Assembles PTPMessageFollowUp message on the
@@ -879,12 +885,16 @@ public:
 	bool sendPort
 	( EtherPort *port, PortIdentity *destIdentity );
 
+	void processMessage( CommonPort *port );
+
 	/**
-	 * @brief  Processes PTP messages
-	 * @param  port [in] EtherPort
-	 * @return void
-	 */
-	void processMessage( EtherPort *port );
+	* @brief Processes PTP messages
+	* @param port [in] CommonPort
+	* @param receipt [in] local time message was received
+	* @param delay
+	* @return void
+	*/
+	void processMessage( CommonPort *port, Timestamp receipt );
 
 	/**
 	 * @brief  Gets the precise origin timestamp value
@@ -916,8 +926,7 @@ public:
 	}
 
 	friend PTPMessageCommon *buildPTPMessage
-	( char *buf, int size, LinkLayerAddress *remote,
-	  EtherPort *port );
+	( char *buf, int size, LinkLayerAddress *remote, CommonPort *port );
 };
 
 /**
@@ -953,12 +962,7 @@ class PTPMessagePathDelayReq : public PTPMessageCommon {
 	bool sendPort
 	( EtherPort *port, PortIdentity *destIdentity );
 
-	/**
-	 * @brief  Processes PTP messages
-	 * @param  port [in] EtherPort
-	 * @return void
-	 */
-	void processMessage( EtherPort *port );
+	void processMessage( CommonPort *port );
 
 	/**
 	 * @brief  Gets origin timestamp value
@@ -969,8 +973,7 @@ class PTPMessagePathDelayReq : public PTPMessageCommon {
 	}
 
 	friend PTPMessageCommon *buildPTPMessage
-	( char *buf, int size, LinkLayerAddress *remote,
-	  EtherPort *port );
+	( char *buf, int size, LinkLayerAddress *remote, CommonPort *port );
 };
 
 /**
@@ -1004,12 +1007,7 @@ public:
 	bool sendPort
 	( EtherPort *port, PortIdentity *destIdentity );
 
-	/**
-	 * @brief  Processes PTP messages
-	 * @param  port [in] EtherPort
-	 * @return void
-	 */
-	void processMessage( EtherPort *port );
+	void processMessage( CommonPort *port );
 
 	/**
 	 * @brief  Sets the request receipt timestamp
@@ -1042,8 +1040,7 @@ public:
 	}
 
 	friend PTPMessageCommon *buildPTPMessage
-	( char *buf, int size, LinkLayerAddress *remote,
-	  EtherPort *port );
+	( char *buf, int size, LinkLayerAddress *remote, CommonPort *port );
 };
 
 /**
@@ -1078,12 +1075,7 @@ public:
 	bool sendPort
 	( EtherPort *port, PortIdentity *destIdentity );
 
-	/**
-	 * @brief  Processes PTP messages
-	 * @param  port [in] EtherPort
-	 * @return void
-	 */
-	void processMessage( EtherPort *port );
+	void processMessage( CommonPort *port );
 
 	/**
 	 * @brief  Sets the response origin timestamp
@@ -1116,8 +1108,7 @@ public:
 	}
 
 	friend PTPMessageCommon *buildPTPMessage
-	( char *buf, int size, LinkLayerAddress *remote,
-	  EtherPort *port );
+	( char *buf, int size, LinkLayerAddress *remote, CommonPort *port );
 };
 
 /*Exact fit. No padding*/
@@ -1267,16 +1258,10 @@ public:
 	bool sendPort
 	( EtherPort *port, PortIdentity *destIdentity );
 
-	/**
-	 * @brief  Processes PTP messages
-	 * @param  port [in] EtherPort
-	 * @return void
-	 */
-	void processMessage( EtherPort *port );
+	void processMessage( CommonPort *port );
 
 	friend PTPMessageCommon *buildPTPMessage
-	( char *buf, int size, LinkLayerAddress *remote,
-	  EtherPort * port);
+	( char *buf, int size, LinkLayerAddress *remote, CommonPort *port );
 };
 
 #endif

--- a/daemons/gptp/common/avbts_osipc.hpp
+++ b/daemons/gptp/common/avbts_osipc.hpp
@@ -36,7 +36,6 @@
 
 #include <stdint.h>
 #include <ptptypes.hpp>
-#include <ether_port.hpp>
 
 /**@file*/
 

--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -61,9 +61,11 @@ CommonPort::CommonPort( PortInit_t *portInit ) :
 	port_state = PTP_INITIALIZING;
 	clock->registerPort(this, ifindex);
 	qualified_announce = NULL;
+	automotive_profile = portInit->automotive_profile;
 	announce_sequence_id = 0;
 	signal_sequence_id = 0;
 	sync_sequence_id = 0;
+	initialLogPdelayReqInterval = portInit->initialLogPdelayReqInterval;
 	initialLogSyncInterval = portInit->initialLogSyncInterval;
 	log_mean_announce_interval = 0;
 	pdelay_count = 0;
@@ -563,7 +565,7 @@ bool CommonPort::processEvent( Event e )
 		else
 		{
 			clock->addEventTimerLocked(this, ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES,
-				ANNOUNCE_RECEIPT_TIMEOUT_MULTIPLIER * pow(2.0, getAnnounceInterval()) * 1000000000.0);
+				(uint64_t) ( ANNOUNCE_RECEIPT_TIMEOUT_MULTIPLIER * pow(2.0, getAnnounceInterval()) * 1000000000.0 ));
 		}
 
 		// Do any media specific initialization
@@ -730,6 +732,11 @@ bool CommonPort::adjustClockPhase( int64_t phase_adjust )
 			HWTimestamper_adjclockphase( phase_adjust );
 
 	return false;
+}
+
+FrequencyRatio CommonPort::getLocalSystemFreqOffset()
+{
+	return clock->getLocalSystemFreqOffset();
 }
 
 Timestamp CommonPort::getTxPhyDelay( uint32_t link_speed ) const

--- a/daemons/gptp/common/ether_port.hpp
+++ b/daemons/gptp/common/ether_port.hpp
@@ -60,10 +60,6 @@
 #define TEST_STATUS_MULTICAST 0x011BC50AC000ULL	/*!< AVnu Automotive profile test status msg Multicast value */
 
 #define PDELAY_RESP_RECEIPT_TIMEOUT_MULTIPLIER 3	/*!< PDelay timeout multiplier*/
-#define SYNC_RECEIPT_TIMEOUT_MULTIPLIER 3			/*!< Sync receipt timeout multiplier*/
-#define ANNOUNCE_RECEIPT_TIMEOUT_MULTIPLIER 3		/*!< Announce receipt timeout multiplier*/
-
-#define LOG2_INTERVAL_INVALID -127	/* Simple out of range Log base 2 value used for Sync and PDelay msg internvals */
 
 /**
  * @brief PortType enumeration. Selects between delay request-response (E2E) mechanism
@@ -98,7 +94,6 @@ class EtherPort : public CommonPort
 	/* Port Configuration */
 	signed char log_mean_unicast_sync_interval;
 	signed char log_min_mean_delay_req_interval;
-	signed char log_min_mean_pdelay_req_interval;
 
 	unsigned int duplicate_resp_counter;
 	uint16_t last_invalid_seqid;
@@ -109,8 +104,6 @@ class EtherPort : public CommonPort
 	// asCapable : already defined as asCapable
 	signed char operLogPdelayReqInterval;
 	signed char operLogSyncInterval;
-	signed char initialLogPdelayReqInterval;
-	bool automotive_profile;
 
 	// Test Status variables
 	uint32_t linkUpCount;
@@ -199,12 +192,6 @@ protected:
 	 * @return void
 	 */
 	void syncDone();
-
-	/**
-	 * @brief  Gets the AVnu automotive profile flag
-	 * @return automotive_profile flag
-	 */
-	bool getAutomotiveProfile() { return( automotive_profile ); }
 
 	/**
 	 * @brief Destroys a EtherPort
@@ -301,31 +288,6 @@ protected:
 	 * @todo Currently not implemented
 	 */
 	void removeForeignMasterAll(void);
-
-	/**
-	 * @brief  Gets the pDelay minimum interval
-	 * @return PDelay interval
-	 */
-	signed char getPDelayInterval(void) {
-		return log_min_mean_pdelay_req_interval;
-	}
-
-	/**
-	 * @brief  Sets the pDelay minimum interval
-	 * @param  val time interval
-	 * @return none
-	 */
-	void setPDelayInterval(signed char val) {
-		log_min_mean_pdelay_req_interval = val;
-	}
-
-	/**
-	 * @brief  Sets the pDelay minimum interval back to initial
-	 *         value
-	 * @return none */
-	void setInitPDelayInterval(void) {
-		log_min_mean_pdelay_req_interval = initialLogPdelayReqInterval;
-	}
 
 	/**
 	 * @brief  Start pDelay interval timer

--- a/daemons/gptp/common/ieee1588.hpp
+++ b/daemons/gptp/common/ieee1588.hpp
@@ -452,16 +452,4 @@ static inline void TIMESTAMP_ADD_NS( Timestamp &ts, uint64_t ns ) {
 	   ts.nanoseconds = (uint32_t)nanos;
 }
 
-/**
- * @brief  Builds a PTP message
- * @param  buf [in] message buffer to send
- * @param  size message length
- * @param  remote Destination link layer address
- * @param  port [in] IEEE1588 port
- * @return PTP message instance of PTPMessageCommon
- */
-PTPMessageCommon *buildPTPMessage
-( char *buf, int size, LinkLayerAddress *remote,
-  EtherPort *port );
-
 #endif

--- a/daemons/gptp/common/wireless_port.cpp
+++ b/daemons/gptp/common/wireless_port.cpp
@@ -1,0 +1,242 @@
+/******************************************************************************
+
+Copyright (c) 2009-2015, Intel Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the Intel Corporation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+******************************************************************************/
+
+#include <wireless_port.hpp>
+#include <wireless_tstamper.hpp>
+#include <avbts_clock.hpp>
+
+WirelessPort::~WirelessPort()
+{
+	// Intentionally left blank
+}
+
+WirelessPort::WirelessPort( PortInit_t *portInit, LinkLayerAddress peer_addr )
+: CommonPort( portInit )
+{
+	this->peer_addr = peer_addr;
+
+	setAsCapable( true );
+	if ( getInitSyncInterval() == LOG2_INTERVAL_INVALID )
+		setInitSyncInterval (-3 );       // 125 ms
+	if ( getInitPDelayInterval() == LOG2_INTERVAL_INVALID )
+		setInitPDelayInterval( 127 );  // 1 second
+
+	prev_dialog.dialog_token = 0;
+}
+
+bool WirelessPort::_init_port(void)
+{
+	port_ready_condition = condition_factory->createCondition();
+
+	return true;
+}
+
+bool WirelessPort::_processEvent( Event e )
+{
+	bool ret;
+
+	switch (e)
+	{
+	default:
+		GPTP_LOG_ERROR
+		("Unhandled event type in "
+			"WirelessPort::processEvent(), %d", e);
+		ret = false;
+		break;
+
+	case POWERUP:
+	case INITIALIZE:
+	{
+		port_ready_condition->wait_prelock();
+
+		if ( !linkOpen(_openPort, (void *)this ))
+		{
+			GPTP_LOG_ERROR( "Error creating port thread" );
+			ret = false;
+			break;
+		}
+
+		port_ready_condition->wait();
+
+		ret = true;
+		break;
+	}
+
+	case SYNC_INTERVAL_TIMEOUT_EXPIRES:
+	{
+		WirelessTimestamper *timestamper =
+			dynamic_cast<WirelessTimestamper *>( _hw_timestamper );
+		PTPMessageFollowUp *follow_up;
+		PortIdentity dest_id;
+		uint16_t seq;
+		uint8_t buffer[128];
+		size_t length;
+
+		memset(buffer, 0, sizeof( buffer ));
+
+		if( prev_dialog.dialog_token != 0 )
+		{
+			follow_up = new PTPMessageFollowUp( this );
+
+			getPortIdentity(dest_id);
+			follow_up->setPortIdentity(&dest_id);
+			follow_up->setSequenceId(prev_dialog.fwup_seq);
+			follow_up->setPreciseOriginTimestamp
+				( prev_dialog.action );
+			length = follow_up->buildMessage
+				(this, buffer + timestamper->getFwUpOffset());
+
+			delete follow_up;
+		}
+
+		seq = getNextSyncSequenceId();
+		ret = timestamper->requestTimingMeasurement
+			( &peer_addr, seq, &prev_dialog, buffer, (int)length )
+			== net_succeed;
+
+		ret = true;
+		break;
+	}
+
+	case ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES:
+	case SYNC_RECEIPT_TIMEOUT_EXPIRES:
+		ret = false;
+		break;
+
+	case STATE_CHANGE_EVENT:
+		ret = false;
+		break;
+	}
+
+	return ret;
+}
+
+bool WirelessPort::openPort()
+{
+	port_ready_condition->signal();
+
+	while (true)
+	{
+		uint8_t buf[128];
+		LinkLayerAddress remote;
+		net_result rrecv;
+		size_t length = sizeof(buf);
+		uint32_t link_speed;
+
+		if(( rrecv = recv( &remote, buf, length, link_speed ))
+		   == net_succeed )
+		{
+			processMessage
+			((char *)buf, (int)length, &remote, link_speed );
+		}
+		else if( rrecv == net_fatal )
+		{
+			GPTP_LOG_ERROR( "read from network interface failed" );
+			this->processEvent( FAULT_DETECTED );
+			break;
+		}
+	}
+
+	return false;
+}
+
+void WirelessPort::sendGeneralPort
+(uint16_t etherType, uint8_t * buf, int len, MulticastType mcast_type,
+	PortIdentity * destIdentity)
+{
+	net_result rtx = send( &peer_addr, etherType, buf, len, false);
+	if( rtx != net_succeed )
+		GPTP_LOG_ERROR( "sendGeneralPort(): failure" );
+
+	return;
+}
+
+void WirelessPort::processMessage
+(char *buf, int length, LinkLayerAddress *remote, uint32_t link_speed)
+{
+	GPTP_LOG_VERBOSE( "Processing network buffer" );
+
+	PTPMessageCommon *msg =
+		buildPTPMessage( buf, (int)length, remote, this );
+
+	if( msg == NULL )
+	{
+		GPTP_LOG_ERROR( "Discarding invalid message" );
+		return;
+	}
+	GPTP_LOG_VERBOSE( "Processing message" );
+
+	if( !msg->isEvent( ))
+	{
+		msg->processMessage( this );
+	} else
+	{
+		GPTP_LOG_ERROR( "Received event message on port "
+				"incapable of processing" );
+		msg->PTPMessageCommon::processMessage( this );
+	}
+
+	if (msg->garbage())
+		delete msg;
+}
+
+void WirelessPort::becomeSlave(bool restart_syntonization)
+{
+	clock->deleteEventTimerLocked(this, ANNOUNCE_INTERVAL_TIMEOUT_EXPIRES);
+	clock->deleteEventTimerLocked( this, SYNC_INTERVAL_TIMEOUT_EXPIRES );
+
+	setPortState( PTP_SLAVE );
+
+	GPTP_LOG_STATUS("Switching to Slave");
+	if( restart_syntonization ) clock->newSyntonizationSetPoint();
+
+	getClock()->updateFUPInfo();
+}
+
+void WirelessPort::becomeMaster(bool annc)
+{
+	setPortState( PTP_MASTER );
+	// Stop announce receipt timeout timer
+	clock->deleteEventTimerLocked( this, ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES);
+
+	// Stop sync receipt timeout timer
+	stopSyncReceiptTimer();
+
+	if (annc)
+		startAnnounce();
+
+	startSyncIntervalTimer( 16000000 );
+	GPTP_LOG_STATUS( "Switching to Master" );
+
+	clock->updateFUPInfo();
+}

--- a/daemons/gptp/common/wireless_port.hpp
+++ b/daemons/gptp/common/wireless_port.hpp
@@ -1,0 +1,179 @@
+/******************************************************************************
+
+Copyright (c) 2009-2015, Intel Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the Intel Corporation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+******************************************************************************/
+
+#ifndef WIRELESS_PORT_HPP
+#define WIRELESS_PORT_HPP
+
+#include <common_port.hpp>
+#include <avbts_oscondition.hpp>
+
+class WirelessDialog
+{
+public:
+	Timestamp action;
+	uint64_t action_devclk;
+	Timestamp ack;
+	uint64_t ack_devclk;
+	uint8_t dialog_token;
+	uint16_t fwup_seq;
+
+	WirelessDialog( uint32_t action, uint32_t ack, uint8_t dialog_token )
+	{
+		this->action_devclk = action; this->ack_devclk = ack;
+		this->dialog_token = dialog_token;
+	}
+
+	WirelessDialog() { dialog_token = 0; }
+
+	WirelessDialog & operator=( const WirelessDialog & a )
+	{
+		if (this != &a)
+		{
+			this->ack = a.ack;
+			this->ack_devclk = a.ack_devclk;
+			this->action = a.action;
+			this->action_devclk = a.action_devclk;
+			this->dialog_token = a.dialog_token;
+			this->fwup_seq = a.fwup_seq;
+		}
+		return *this;
+	}
+};
+
+class WirelessPort : public CommonPort
+{
+private:
+	OSCondition *port_ready_condition;
+	LinkLayerAddress peer_addr;
+	WirelessDialog prev_dialog;
+
+public:
+	WirelessPort( PortInit_t *portInit, LinkLayerAddress peer_addr );
+	virtual ~WirelessPort();
+
+	/**
+	* @brief Media specific port initialization
+	* @return true on success
+	*/
+	bool _init_port( void );
+
+	/**
+	* @brief Perform media specific event handling action
+	* @return true if event is handled without errors
+	*/
+	bool _processEvent( Event e );
+
+	/**
+	* @brief Process message
+	* @param buf [in] Pointer to the data buffer
+	* @param length Size of the message
+	* @param remote [in] source address of message
+	* @param link_speed [in] for receive operation
+	* @return void
+	*/
+	void processMessage
+	(char *buf, int length, LinkLayerAddress *remote, uint32_t link_speed);
+
+	/**
+	* @brief Sends a general message to a port. No timestamps
+	* @param buf [in] Pointer to the data buffer
+	* @param len Size of the message
+	* @param mcast_type Enumeration
+	* MulticastType (pdelay, none or other). Depracated.
+	* @param destIdentity Destination port identity
+	* @return void
+	*/
+	void sendGeneralPort
+	( uint16_t etherType, uint8_t * buf, int len, MulticastType mcast_type,
+	  PortIdentity * destIdentity );
+
+	/**
+	* @brief Nothing required for wireless port
+	*/
+	void syncDone() {}
+
+	/**
+	* @brief  Switches port to a gPTP master
+	* @param  annc If TRUE, starts announce event timer.
+	* @return void
+	*/
+	void becomeMaster( bool annc );
+
+	/**
+	* @brief  Switches port to a gPTP slave.
+	* @param  restart_syntonization if TRUE, restarts the syntonization
+	* @return void
+	*/
+	void becomeSlave( bool restart_syntonization );
+
+	/**
+	* @brief Receives messages from the network interface
+	* @return Its an infinite loop. Returns false in case of error.
+	*/
+	bool openPort();
+
+	/**
+	 * @brief Wraps open port method for argument to thread
+	 * @param larg pointer to WirelessPort object
+	 * @return thread exit code
+	 */
+	static OSThreadExitCode _openPort( void *larg )
+	{
+		WirelessPort *port = (decltype(port))larg;
+
+		if (!port->openPort())
+			return osthread_error;
+
+		return osthread_ok;
+	}
+
+	/**
+	* @brief Sets previous dialog
+	* @param dialog new value of prev_dialog
+	*/
+	void setPrevDialog( WirelessDialog *dialog )
+	{
+		prev_dialog = *dialog;
+	}
+
+	/**
+	* @brief Sets previous dialog
+	* @return reference to prev_dialog
+	*/
+	WirelessDialog *getPrevDialog( void )
+	{
+		return &prev_dialog;
+	}
+};
+
+#endif/*WIRELESS_PORT_HPP*/

--- a/daemons/gptp/common/wireless_tstamper.cpp
+++ b/daemons/gptp/common/wireless_tstamper.cpp
@@ -1,0 +1,127 @@
+/******************************************************************************
+
+Copyright (c) 2009-2015, Intel Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the Intel Corporation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+******************************************************************************/
+
+#include <wireless_tstamper.hpp>
+#include <wireless_port.hpp>
+
+net_result WirelessTimestamper::requestTimingMeasurement
+( LinkLayerAddress *dest, uint16_t seq, WirelessDialog *prev_dialog,
+  uint8_t *follow_up, int followup_length )
+{
+	WirelessDialog next_dialog;
+	net_result retval;
+	TIMINGMSMT_REQUEST *req;
+
+	// Valid dialog token > 0 && < 256
+	next_dialog.dialog_token = (seq % MAX_DIALOG_TOKEN) + 1;
+	next_dialog.fwup_seq = seq;
+	next_dialog.action_devclk = 0;
+	req = (TIMINGMSMT_REQUEST *)follow_up;
+
+	// File in request
+	req->DialogToken = next_dialog.dialog_token;
+	req->FollowUpDialogToken = prev_dialog->dialog_token;
+	req->Category = 0x0;
+	req->Action = 0x0;
+	req->WiFiVSpecHdr.ElementId = FWUP_VDEF_TAG;
+	req->WiFiVSpecHdr.Length = 0;
+	if( req->FollowUpDialogToken != 0 && prev_dialog->action_devclk != 0 )
+	{
+		req->T1 = (uint32_t)prev_dialog->action_devclk;
+		req->T4 = (uint32_t)prev_dialog->ack_devclk;
+		req->WiFiVSpecHdr.Length = followup_length +
+			(uint8_t)sizeof(FwUpLabel); // 1 byte type
+		req->PtpSpec.FwUpLabel = FwUpLabel;
+	}
+	dest->toOctetArray(req->PeerMACAddress);
+
+	retval = _requestTimingMeasurement( req );
+	port->setPrevDialog(&next_dialog);
+
+	return retval;
+}
+
+void WirelessTimestamper::timingMeasurementConfirmCB
+( LinkLayerAddress addr, WirelessDialog *dialog )
+{
+	WirelessDialog *prev_dialog = port->getPrevDialog();
+
+	// Translate action dev clock to Timestamp
+	// ACK timestamp isn't needed
+	dialog->action.set64(dialog->action_devclk*10);
+
+	if (dialog->dialog_token == prev_dialog->dialog_token)
+	{
+		dialog->fwup_seq = prev_dialog->fwup_seq;
+		port->setPrevDialog(dialog);
+	}
+}
+
+void WirelessTimestamper::timeMeasurementIndicationCB
+( LinkLayerAddress addr, WirelessDialog *current, WirelessDialog *previous,
+  uint8_t *buf, size_t buflen )
+{
+	uint64_t link_delay;
+	WirelessDialog *prev_local;
+	PTPMessageCommon *msg;
+	PTPMessageFollowUp *fwup;
+	// Translate devclk scalar to Timestamp
+
+	msg = buildPTPMessage((char *)buf, (int)buflen, &addr, port);
+	fwup = dynamic_cast<PTPMessageFollowUp *> (msg);
+	current->action_devclk *= 10;
+	current->ack_devclk *= 10;
+	current->action.set64(current->action_devclk);
+	prev_local = port->getPrevDialog();
+	if ( previous->dialog_token == prev_local->dialog_token &&
+	     fwup != NULL && previous->action_devclk != 0)
+	{
+		previous->action_devclk *= 10;
+		previous->ack_devclk *= 10;
+		unsigned round_trip = (unsigned)
+			(previous->ack_devclk - previous->action_devclk);
+		unsigned turn_around = (unsigned)
+			(prev_local->ack_devclk - prev_local->action_devclk);
+		link_delay = (round_trip - turn_around) / 2;
+		port->setLinkDelay(link_delay);
+		GPTP_LOG_VERBOSE( "Link Delay = %llu(RT=%u,TA=%u,"
+				  "T4=%llu,T1=%llu,DT=%hhu)",
+				  link_delay, round_trip, turn_around,
+				  previous->ack_devclk,
+				  previous->action_devclk,
+				  previous->dialog_token);
+		fwup->processMessage(port, prev_local->action);
+	}
+
+	port->setPrevDialog(current);
+}

--- a/daemons/gptp/common/wireless_tstamper.hpp
+++ b/daemons/gptp/common/wireless_tstamper.hpp
@@ -1,0 +1,221 @@
+/******************************************************************************
+
+Copyright (c) 2009-2015, Intel Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the Intel Corporation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+******************************************************************************/
+
+#ifndef WIRELESS_TSTAMPER_HPP
+#define WIRELESS_TSTAMPER_HPP
+
+#include <common_tstamper.hpp>
+#include <wireless_port.hpp>
+
+#define MAX_DIALOG_TOKEN 255
+#define OUI_8021AS_OCTETS { 0x00, 0x80, 0xC2 }
+static const uint8_t OUI_8021AS[] = OUI_8021AS_OCTETS;
+#define FWUP_TYPE 0
+#define FWUP_VDEF_TAG 0xDD /* Vendor Defined Tag */
+
+typedef enum _WIRELESS_EVENT_TYPE
+{
+	TIMINGMSMT_EVENT = 0,
+	TIMINGMSMT_CONFIRM_EVENT,
+	TIMINGMSMT_CORRELATEDTIME_EVENT,
+} WIRELESS_EVENT_TYPE;
+
+#pragma pack(push, 1)
+typedef struct
+{
+	uint8_t oui[sizeof(OUI_8021AS)];
+	uint8_t type;
+} FwUpLabel_t;
+
+typedef struct _PTP_SPEC
+{
+	FwUpLabel_t	FwUpLabel;
+	uint8_t		fwup_data[1];
+} PTP_SPEC;
+
+static const FwUpLabel_t FwUpLabel = { OUI_8021AS_OCTETS, FWUP_TYPE };
+
+typedef struct _WIFI_VENDOR_SPEC_HDR
+{
+	uint8_t		ElementId;
+	uint8_t		Length;
+} WIFI_VENDOR_SPEC_HDR;
+#pragma pack(pop)
+
+typedef struct _TIMINGMSMT_REQUEST
+{
+	uint8_t		PeerMACAddress[ETHER_ADDR_OCTETS];
+	uint8_t		Category;
+	uint8_t		Action;
+	uint8_t		DialogToken;
+	uint8_t		FollowUpDialogToken;
+	uint32_t	T1;
+	uint32_t	T4;
+	uint8_t		MaxT1Error;
+	uint8_t		MaxT4Error;
+
+	WIFI_VENDOR_SPEC_HDR	WiFiVSpecHdr;
+	PTP_SPEC				PtpSpec;
+} TIMINGMSMT_REQUEST;
+
+typedef struct _TIMINGMSMT_EVENT_DATA
+{
+	uint8_t		PeerMACAddress[ETHER_ADDR_OCTETS];
+	uint32_t	DialogToken;
+	uint32_t	FollowUpDialogToken;
+	uint64_t	T1;
+	uint32_t	MaxT1Error;
+	uint64_t	T4;
+	uint32_t	MaxT4Error;
+	uint64_t	T2;
+	uint32_t	MaxT2Error;
+	uint64_t	T3;
+	uint32_t	MaxT3Error;
+
+	WIFI_VENDOR_SPEC_HDR	WiFiVSpecHdr;
+	PTP_SPEC				PtpSpec;
+} TIMINGMSMT_EVENT_DATA;
+
+typedef struct _TIMINGMSMT_CONFIRM_EVENT_DATA
+{
+	uint8_t		PeerMACAddress[ETHER_ADDR_OCTETS];
+	uint32_t	DialogToken;
+	uint64_t	T1;
+	uint32_t	MaxT1Error;
+	uint64_t	T4;
+	uint32_t	MaxT4Error;
+} TIMINGMSMT_CONFIRM_EVENT_DATA;
+
+typedef struct _WIRELESS_CORRELATEDTIME
+{
+	uint64_t	TSC;
+	uint64_t	LocalClk;
+} WIRELESS_CORRELATEDTIME;
+
+struct S8021AS_Indication {
+	TIMINGMSMT_EVENT_DATA indication;
+	uint8_t followup[75]; // (34 header + 10 followup + 32 TLV) - 1 byte contained in indication struct = 75
+};
+
+union TimeSyncEventData
+{
+	TIMINGMSMT_CONFIRM_EVENT_DATA confirm;
+	S8021AS_Indication indication;
+	WIRELESS_CORRELATEDTIME ptm_wa;
+};
+
+class WirelessTimestamper : public CommonTimestamper
+{
+private:
+	WirelessPort *port;
+public:
+	virtual ~WirelessTimestamper() {}
+
+	/**
+	 * @brief attach timestamper to port
+	 * @param port port to attach
+	 */
+	void setPort( WirelessPort *port )
+	{
+		this->port = port;
+	}
+
+	/**
+	 * @brief return reference to attached port
+	 * @return reference to attached port
+	 */
+	WirelessPort *getPort(void) const
+	{
+		return port;
+	}
+
+	/**
+	 * @brief Return buffer offset where followup message should be placed
+	 * @return byte offset
+	 */
+	uint8_t getFwUpOffset(void)
+	{
+		// Subtract 1 to compensate for 'bogus' vendor specific buffer
+		// length
+		return (uint8_t)((size_t) &((TIMINGMSMT_REQUEST *) 0)->
+				 PtpSpec.fwup_data );
+	}
+
+	/**
+	 * @brief Request transmission of TM frame
+	 * @param dest [in] MAC destination the frame should be sent to
+	 * @param seq [in] 802.1AS sequence number
+	 * @param prev_dialog [in] last dialog message
+	 * @param follow_up [in] buffer containing followup message
+	 * @param followup_length [in] fw-up message length in bytes
+	 */
+	virtual net_result requestTimingMeasurement
+	( LinkLayerAddress *dest, uint16_t seq, WirelessDialog *prev_dialog,
+	  uint8_t *follow_up, int followup_length );
+
+	/**
+	 * @brief abstract method for driver/os specific TM transmit code
+	 * @param timingmsmt_req fully formed TM message
+	 */
+	virtual net_result _requestTimingMeasurement
+	( TIMINGMSMT_REQUEST *timingmsmt_req ) = 0;
+
+	/**
+	 * @brief Asynchronous completion of TM transmit
+	 * @param addr [in] MAC the message was transmitted to
+	 * @param dialog [in] dialog filled with T1, T4 timestamps
+	 */
+	void timingMeasurementConfirmCB( LinkLayerAddress addr,
+					 WirelessDialog *dialog );
+
+	/**
+	 * @brief Reception of TM frame
+	 * @param addr [in] MAC the message was received from
+	 * @param current [in] dialog filled with T2, T3 timestamps
+	 * @param previous [in] dialog filled with T1, T4 timestamps
+	 * @param buf [in] buffer containing followup message
+	 * @param previous [in] length of followup message
+	 */
+	void timeMeasurementIndicationCB
+	( LinkLayerAddress addr, WirelessDialog *current,
+	  WirelessDialog *previous, uint8_t *buf, size_t buflen );
+};
+
+struct WirelessTimestamperCallbackArg
+{
+	WIRELESS_EVENT_TYPE iEvent_type;
+	WirelessTimestamper *timestamper;
+	TimeSyncEventData event_data;
+};
+
+#endif/*WIRELESS_TSTAMPER_HPP*/

--- a/daemons/gptp/linux/src/daemon_cl.cpp
+++ b/daemons/gptp/linux/src/daemon_cl.cpp
@@ -37,6 +37,7 @@
 #include "avbts_oslock.hpp"
 #include "avbts_persist.hpp"
 #include "gptp_cfg.hpp"
+#include "ether_port.hpp"
 
 #ifdef ARCH_INTELCE
 #include "linux_hal_intelce.hpp"

--- a/daemons/gptp/windows/daemon_cl/intel_wireless.cpp
+++ b/daemons/gptp/windows/daemon_cl/intel_wireless.cpp
@@ -1,0 +1,424 @@
+/******************************************************************************
+
+Copyright (c) 2009-2015, Intel Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the Intel Corporation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+******************************************************************************/
+
+#include <intel_wireless.hpp>
+#include <windows_hal.hpp>
+#include <work_queue.hpp>
+#include <memory>
+#include <map>
+
+#define INTEL_EVENT_OFFSET 0x1141
+#define GP2_ROLLOVER 4294967296ULL
+
+GetAdapterList_t GetAdapterList;
+WifiCmdTimingMeasurementRequest_t WifiCmdTimingMeasurementRequest;
+WifiCmdTimingPtmWa_t WifiCmdTimingPtmWa;
+RegisterIntelCallback_t RegisterIntelCallback;
+DeregisterIntelCallback_t DeregisterIntelCallback;
+
+struct TimestamperContext
+{
+	WindowsWorkQueue work_queue;
+	WindowsWirelessTimestamper *timestamper;
+	~TimestamperContext()
+	{
+		work_queue.stop();
+	}
+};
+
+typedef std::map< LinkLayerAddress, TimestamperContext > TimestamperContextMap;
+
+class LockedTimestamperContextMap
+{
+public:
+	LockedTimestamperContextMap()
+	{
+		InitializeSRWLock(&lock);
+	}
+	TimestamperContextMap map;
+	SRWLOCK lock;
+};
+
+LockedTimestamperContextMap timestamperContextMap;
+HANDLE IntelTimestamperThread;
+bool IntelTimestamperThreadStop = false;
+
+void IntelWirelessTimestamperEventHandler( INTEL_EVENT iEvent, void *pContext )
+{
+	WindowsWirelessTimestamper *timestamper;
+	IntelWirelessAdapter *adapter;
+	LockedTimestamperContextMap *timestamperContextMap =
+		(LockedTimestamperContextMap *)pContext;
+	WirelessTimestamperCallbackArg *arg =
+		new WirelessTimestamperCallbackArg();
+	int vendor_extension_copy_length;
+	bool error = false;
+	bool submit = false; // If true submit the event for later processing
+
+	// We share driver callback with other events, subtract the offset for
+	// timing measurement related events and check this is time sync event
+	iEvent.eType =
+		(WIRELESS_EVENT_TYPE) (iEvent.eType - INTEL_EVENT_OFFSET);
+	switch( iEvent.eType )
+	{
+	default:
+		return;
+	case TIMINGMSMT_CONFIRM_EVENT:
+	case TIMINGMSMT_EVENT:
+	case TIMINGMSMT_CORRELATEDTIME_EVENT:
+		break;
+	}
+
+	LinkLayerAddress event_source( iEvent.BtMacAddress );
+	arg->iEvent_type = (WIRELESS_EVENT_TYPE) iEvent.eType;
+	AcquireSRWLockShared( &timestamperContextMap->lock );
+	if( timestamperContextMap->map.find( event_source )
+	    != timestamperContextMap->map.cend())
+	{
+		arg->timestamper =
+			timestamperContextMap->map[event_source].timestamper;
+	} else
+	{
+		goto bail;
+	}
+
+	timestamper = dynamic_cast <WindowsWirelessTimestamper *>
+		(arg->timestamper);
+	if( timestamper == NULL )
+	{
+		GPTP_LOG_ERROR( "Unexpected timestamper type encountered" );
+		goto bail;
+	}
+	adapter = dynamic_cast <IntelWirelessAdapter *>
+		(timestamper->getAdapter( ));
+	if( adapter == NULL )
+	{
+		GPTP_LOG_ERROR( "Unexpected adapter type encountered" );
+		goto bail;
+	}
+
+	// The driver implementation makes no guarantee of the lifetime of the
+	// iEvent object we make a copy and delete the copy when processing is
+	// complete
+	switch( arg->iEvent_type )
+	{
+	case TIMINGMSMT_CONFIRM_EVENT:
+		arg->event_data.confirm =
+			*(TIMINGMSMT_CONFIRM_EVENT_DATA *)iEvent.data;
+		arg->event_data.confirm.T1 =
+			adapter->calc_rollover( arg->event_data.confirm.T1 );
+		arg->event_data.confirm.T4 =
+			adapter->calc_rollover( arg->event_data.confirm.T4 );
+		submit = true;
+
+		break;
+
+	case TIMINGMSMT_EVENT:
+		arg->event_data.indication.indication =
+			*(TIMINGMSMT_EVENT_DATA *)iEvent.data;
+		arg->event_data.indication.indication.T2 =
+			adapter->calc_rollover
+			( arg->event_data.indication.indication.T2/100 );
+		arg->event_data.indication.indication.T3 =
+			adapter->calc_rollover
+			( arg->event_data.indication.indication.T3/100 );
+		// Calculate copy length, at most followup message
+		// (See S8021AS indication)
+		vendor_extension_copy_length = arg->event_data.
+			indication.indication.WiFiVSpecHdr.Length - 1;
+		vendor_extension_copy_length -= vendor_extension_copy_length -
+			sizeof(arg->event_data.indication.followup) > 0 ?
+			vendor_extension_copy_length -
+			sizeof(arg->event_data.indication.followup) : 0;
+		// Copy the rest of the vendor specific field
+		memcpy( arg->event_data.indication.followup,
+			((BYTE *)iEvent.data) +
+			sizeof( arg->event_data.indication.indication ),
+			vendor_extension_copy_length );
+		submit = true;
+		break;
+	case TIMINGMSMT_CORRELATEDTIME_EVENT:
+		AcquireSRWLockExclusive(&adapter->ct_lock);
+		if (adapter->ct_miss > 0)
+		{
+			--adapter->ct_miss;
+		} else
+		{
+			arg->event_data.ptm_wa =
+				*(WIRELESS_CORRELATEDTIME *)iEvent.data;
+			arg->event_data.ptm_wa.LocalClk =
+				adapter->calc_rollover
+				(arg->event_data.ptm_wa.LocalClk);
+			adapter->ct_done = true;
+			// No need to schedule this, it returns immediately
+			WirelessTimestamperCallback(arg);
+			WakeAllConditionVariable(&adapter->ct_cond);
+		}
+		ReleaseSRWLockExclusive(&adapter->ct_lock);
+
+		break;
+	}
+
+	if (submit &&
+	    !timestamperContextMap->map[event_source].work_queue.submit
+	    ( WirelessTimestamperCallback, arg ))
+		GPTP_LOG_ERROR("Failed to submit WiFi event");
+bail:
+	ReleaseSRWLockShared(&timestamperContextMap->lock);
+}
+
+DWORD WINAPI IntelWirelessLoop(LPVOID arg)
+{
+	// Register for callback
+	INTEL_CALLBACK tempCallback;
+	tempCallback.fnIntelCallback = IntelWirelessTimestamperEventHandler;
+	tempCallback.pContext = arg;
+
+	if (RegisterIntelCallback(&tempCallback) != S_OK) {
+		GPTP_LOG_ERROR( "Failed to register WiFi callback" );
+		return 0;
+	}
+
+	while (!IntelTimestamperThreadStop)
+	{
+		SleepEx(320, true);
+	}
+
+	DeregisterIntelCallback(tempCallback.fnIntelCallback);
+
+	return 0;
+}
+
+bool IntelWirelessAdapter::initialize(void)
+{
+	HMODULE MurocApiDLL = LoadLibrary("MurocApi.dll");
+
+	GetAdapterList = (GetAdapterList_t)
+		GetProcAddress(MurocApiDLL, "GetAdapterList");
+	if( GetAdapterList == NULL )
+		return false;
+
+	RegisterIntelCallback =	(RegisterIntelCallback_t)
+		GetProcAddress(MurocApiDLL, "RegisterIntelCallback");
+	if( RegisterIntelCallback == NULL )
+		return false;
+
+	DeregisterIntelCallback = (DeregisterIntelCallback_t)
+		GetProcAddress(MurocApiDLL, "DeregisterIntelCallback");
+	if( DeregisterIntelCallback == NULL )
+		return false;
+
+	WifiCmdTimingPtmWa = (WifiCmdTimingPtmWa_t)
+		GetProcAddress(MurocApiDLL, "WifiCmdTimingPtmWa");
+	if( WifiCmdTimingPtmWa == NULL )
+		return false;
+
+	WifiCmdTimingMeasurementRequest = (WifiCmdTimingMeasurementRequest_t)
+		GetProcAddress(MurocApiDLL, "WifiCmdTimingMeasurementRequest");
+	if (WifiCmdTimingMeasurementRequest == NULL)
+		return false;
+
+	// Initialize crosstimestamp condition
+	InitializeConditionVariable(&ct_cond);
+	InitializeSRWLock(&ct_lock);
+	ct_miss = 0;
+
+	// Spawn thread
+	IntelTimestamperThread = CreateThread
+		( NULL, 0, IntelWirelessLoop, &timestamperContextMap, 0, NULL);
+	return true;
+}
+
+void IntelWirelessAdapter::shutdown(void) {
+	// Signal thread exit
+	IntelTimestamperThreadStop = true;
+	// Join thread
+	WaitForSingleObject(IntelTimestamperThread, INFINITE);
+}
+
+bool IntelWirelessAdapter::refreshCrossTimestamp(void) {
+	INTEL_WIFI_HEADER header;
+	WIRELESS_CORRELATEDTIME ptm_wa;
+	DWORD wait_return = TRUE;
+	DWORD start = 0;
+
+	AcquireSRWLockExclusive(&ct_lock);
+	ct_done = false;
+	header.dwSize = sizeof(ptm_wa);
+	header.dwStructVersion = INTEL_STRUCT_VER_LATEST;
+	HRESULT hres = WifiCmdTimingPtmWa(hAdapter, &header, &ptm_wa);
+	if (hres != S_OK)
+		return false;
+
+	while (!ct_done && wait_return == TRUE) {
+		DWORD now = GetTickCount();
+		start = start == 0 ? now : start;
+		DWORD wait = now - start < CORRELATEDTIME_TRANSACTION_TIMEOUT ?
+					   CORRELATEDTIME_TRANSACTION_TIMEOUT -
+					   (now - start) : 0;
+		wait_return = SleepConditionVariableSRW
+					   ( &ct_cond, &ct_lock, wait, 0 );
+	}
+	ct_miss += wait_return != TRUE ? 1 : 0;
+	ReleaseSRWLockExclusive(&ct_lock);
+
+	return wait_return == TRUE ? true : false;
+}
+
+bool IntelWirelessAdapter::initiateTimingRequest
+( TIMINGMSMT_REQUEST *tm_request )
+{
+	INTEL_WIFI_HEADER header;
+	HRESULT err;
+
+	memset(&header, 0, sizeof(header));
+	// Proset wants an equivalent, but slightly different struct definition
+	header.dwSize = sizeof(*tm_request) - sizeof(PTP_SPEC) + 1;
+	header.dwStructVersion = INTEL_STRUCT_VER_LATEST;
+	if(( err = WifiCmdTimingMeasurementRequest
+	     (hAdapter, &header, tm_request)) != S_OK )
+		return false;
+
+	return true;
+}
+
+// Find Intel adapter given MAC address and return adapter ID
+//
+// @adapter(out): Adapter identifier used for all driver interaction
+// @mac_addr: HW address of the adapter
+// @return: *false* if adapter is not found or driver communication failure
+//		occurs, otherwise *true*
+//
+bool IntelWirelessAdapter::attachAdapter(uint8_t *mac_addr)
+{
+	PINTEL_ADAPTER_LIST adapter_list;
+	int i;
+
+	if (GetAdapterList(&adapter_list) != S_OK)
+		return false;
+
+	GPTP_LOG_VERBOSE("Driver query returned %d adapters\n",
+			 adapter_list->count);
+	for (i = 0; i < adapter_list->count; ++i) {
+		if( memcmp(adapter_list->adapter[i].btMACAddress,
+			   mac_addr, ETHER_ADDR_OCTETS) == 0 )
+			break;
+	}
+
+	if (i == adapter_list->count)
+	{
+		GPTP_LOG_ERROR("Driver failed to find the requested adapter");
+		return false;
+	}
+	hAdapter = adapter_list->adapter[i].hAdapter;
+
+	return true;
+}
+
+// Register timestamper with Intel wireless subsystem.
+//
+// @timestamper: timestamper object that should receive events
+// @source: MAC address of local interface
+// @return: *false* if the MAC address has already been registered, *true* if
+//
+bool IntelWirelessAdapter::registerTimestamper
+(WindowsWirelessTimestamper *timestamper)
+{
+	bool ret = false;
+
+	AcquireSRWLockExclusive(&timestamperContextMap.lock);
+	// Do not "re-add" the same timestamper
+	if( timestamperContextMap.map.find
+	    ( *timestamper->getPort()->getLocalAddr() )
+	    == timestamperContextMap.map.cend())
+	{
+		// Initialize per timestamper context and add
+		timestamperContextMap.map
+			[*timestamper->getPort()->getLocalAddr()].
+			work_queue.init(0);
+		timestamperContextMap.map
+			[*timestamper->getPort()->getLocalAddr()].
+			timestamper = timestamper;
+		ret = true;
+	}
+	ReleaseSRWLockExclusive(&timestamperContextMap.lock);
+
+	return ret;
+}
+
+bool IntelWirelessAdapter::deregisterTimestamper
+( WindowsWirelessTimestamper *timestamper )
+{
+	bool ret;
+
+	TimestamperContextMap::iterator iter;
+	AcquireSRWLockExclusive(&timestamperContextMap.lock);
+	// Find timestamper
+	iter = timestamperContextMap.map.find
+		( *timestamper->getPort()->getLocalAddr( ));
+	if( iter != timestamperContextMap.map.end( ))
+	{
+		// Shutdown work queue
+		iter->second.work_queue.stop();
+		// Remove timestamper from list
+		timestamperContextMap.map.erase(iter);
+		ret = true;
+	}
+	ReleaseSRWLockExclusive(&timestamperContextMap.lock);
+
+	return ret;
+}
+
+uint64_t IntelWirelessAdapter::calc_rollover( uint64_t gp2 )
+{
+	gp2 = gp2 & 0xFFFFFFFF;
+	uint64_t l_gp2_ext;
+
+	if (gp2_last == ULLONG_MAX)
+	{
+		gp2_last = gp2;
+
+		return gp2;
+	}
+
+	if (gp2 < GP2_ROLLOVER/4 && gp2_last > (GP2_ROLLOVER*3)/4)
+		++gp2_ext;
+
+	l_gp2_ext = gp2_ext;
+	if( gp2_last < GP2_ROLLOVER / 4 && gp2 >(GP2_ROLLOVER * 3) / 4 )
+		--l_gp2_ext;
+	else
+		gp2_last = gp2;
+
+	return gp2 + ( l_gp2_ext * GP2_ROLLOVER );
+}

--- a/daemons/gptp/windows/daemon_cl/intel_wireless.hpp
+++ b/daemons/gptp/windows/daemon_cl/intel_wireless.hpp
@@ -1,0 +1,187 @@
+/******************************************************************************
+
+Copyright (c) 2009-2015, Intel Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the Intel Corporation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+******************************************************************************/
+
+#ifndef INTEL_WIRELESS_HPP
+#define INTEL_WIRELESS_HPP
+
+#include <windows_hal.hpp>
+#include <Windows.h>
+#include <stdint.h>
+
+#define INTEL_MAC_ADDR_LENGTH				6
+#define INTEL_MAX_ADAPTERS					20
+#define CORRELATEDTIME_TRANSACTION_TIMEOUT	110/*ms*/
+
+enum _WIRELESS_EVENT_TYPE;
+
+typedef struct INTEL_EVENT
+{
+	BYTE			BtMacAddress[INTEL_MAC_ADDR_LENGTH + 1];
+	///< Source of event (MAC address)
+	_WIRELESS_EVENT_TYPE	eType; ///< Event type
+	HRESULT			hErrCode; ///< Error code
+	DWORD			dwSize;
+	BYTE*			data;
+} INTEL_EVENT, *PINTEL_EVENT;
+
+typedef void(*INTEL_EVENT_CALLBACK) ( INTEL_EVENT iEvent, void *pContext );
+
+typedef struct INTEL_CALLBACK
+{
+	INTEL_EVENT_CALLBACK	fnIntelCallback;
+	void			*pContext;
+
+} INTEL_CALLBACK, *PINTEL_CALLBACK;
+
+/// Adapter handle
+typedef DWORD HADAPTER;
+
+//intel Header structure
+typedef struct _INTEL_WIFI_HEADER
+{
+	DWORD	dwStructVersion;
+	//Structure version for which this header is created
+	DWORD	dwSize;
+	//size of the structure for which this header is created
+	DWORD	dwFlags;				//For future use
+	DWORD	dwReserved;				//For future use
+} INTEL_WIFI_HEADER, *PINTEL_WIFI_HEADER;
+
+typedef enum INTEL_ADAPTER_TYPE
+{
+	eStone,		// Stone Peak - without BT Support
+	eStoneBT,	// Stone Peak - with BT Support
+	eSnowfield	// Snowfield Peak
+} INTEL_ADAPTER_TYPE;
+
+#define INTEL_ADAPTER_NAME_SIZE			64
+#define INTEL_ADAPTER_DESCRIPTION_SIZE		64
+#define INTEL_ADAPTER_CLSGUID_SIZE		64
+#define INTEL_REGPATH_SIZE			512
+
+#define INTEL_STRUCT_VER_LATEST			156
+
+typedef enum INTEL_ADAPTER_PROTOCOL
+{
+	eUnknownProtocol,	///< Unknown adapter.
+	e802_11,		///< WiFi
+} INTEL_ADAPTER_PROTOCOL;
+
+typedef struct INTEL_ADAPTER_LIST_ENTRY
+{
+	HADAPTER hAdapter;
+	///< Adapter handle
+	UCHAR btMACAddress[INTEL_MAC_ADDR_LENGTH];
+	///< Adapter MAC address
+	CHAR szAdapterName[INTEL_ADAPTER_NAME_SIZE];
+	///< Adapter OS CLSGUID
+	CHAR szAdapterDescription[INTEL_ADAPTER_DESCRIPTION_SIZE];
+	///< Display name
+	CHAR szAdapterClsguid[INTEL_ADAPTER_CLSGUID_SIZE];
+	///< Muroc CLSGUID
+	CHAR szRegistryPath[INTEL_REGPATH_SIZE];
+	///< Adapter registry root
+	CHAR szPnPId[INTEL_REGPATH_SIZE];		///< Plug-and-Play ID
+	BOOL bEnabled;					///< enabled in driver
+	INTEL_ADAPTER_TYPE eAdapterType;		///< Adapter type
+	INTEL_ADAPTER_PROTOCOL eAdapterProtocol;	///< Adapter type
+} INTEL_ADAPTER_LIST_ENTRY, *PINTEL_ADAPTER_LIST_ENTRY;
+
+typedef struct INTEL_ADAPTER_LIST
+{
+	int count; ///< Number of entries
+	INTEL_ADAPTER_LIST_ENTRY adapter[INTEL_MAX_ADAPTERS];
+	///< Array of adapter entries
+} INTEL_ADAPTER_LIST, *PINTEL_ADAPTER_LIST;
+
+
+typedef HRESULT ( APIENTRY *GetAdapterList_t )
+	( PINTEL_ADAPTER_LIST* ppAdapterList );
+typedef HRESULT ( APIENTRY *WifiCmdTimingMeasurementRequest_t )
+	( HADAPTER, PINTEL_WIFI_HEADER, void * );
+typedef HRESULT ( APIENTRY *WifiCmdTimingPtmWa_t )
+	(HADAPTER, PINTEL_WIFI_HEADER, void *);
+typedef HRESULT ( APIENTRY *RegisterIntelCallback_t ) ( PINTEL_CALLBACK );
+typedef HRESULT ( APIENTRY *DeregisterIntelCallback_t )
+	( INTEL_EVENT_CALLBACK );
+
+extern GetAdapterList_t GetAdapterList;
+extern WifiCmdTimingMeasurementRequest_t WifiCmdTimingMeasurementRequest;
+extern WifiCmdTimingPtmWa_t WifiCmdTimingPtmWa;
+extern RegisterIntelCallback_t RegisterIntelCallback;
+extern DeregisterIntelCallback_t DeregisterIntelCallback;
+
+typedef struct _TIMINGMSMT_REQUEST *tm_request_t;
+typedef struct WirelessTimestamperCallbackArg
+*WirelessTimestamperCallbackArg_t;
+typedef void( *WirelessTimestamperCallback_t )
+( WirelessTimestamperCallbackArg_t arg );
+
+class IntelWirelessAdapter : public WindowsWirelessAdapter
+{
+private:
+	HADAPTER hAdapter;
+
+	// Get correlated time operation may timeout
+	// Use condition wait to manage this
+	SRWLOCK ct_lock;
+	CONDITION_VARIABLE ct_cond;
+	bool ct_done;
+	int ct_miss;
+
+	uint64_t gp2_last;
+	unsigned gp2_ext;
+
+public:
+	bool initialize( void );
+	void shutdown( void );
+	bool refreshCrossTimestamp();
+	bool initiateTimingRequest( TIMINGMSMT_REQUEST *tm_request );
+	bool attachAdapter( uint8_t *mac_addr );
+	bool registerTimestamper( WindowsWirelessTimestamper *timestamper );
+	bool deregisterTimestamper( WindowsWirelessTimestamper *timestamper );
+	IntelWirelessAdapter();
+
+	uint64_t calc_rollover( uint64_t gp2 );
+
+	friend void IntelWirelessTimestamperEventHandler
+	( INTEL_EVENT iEvent, void *pContext );
+};
+
+inline IntelWirelessAdapter::IntelWirelessAdapter()
+{
+	gp2_ext = 0;
+	gp2_last = ULLONG_MAX;
+}
+
+#endif

--- a/daemons/gptp/windows/daemon_cl/work_queue.cpp
+++ b/daemons/gptp/windows/daemon_cl/work_queue.cpp
@@ -1,0 +1,106 @@
+/******************************************************************************
+
+Copyright (c) 2009-2015, Intel Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the Intel Corporation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+******************************************************************************/
+
+#include <work_queue.hpp>
+#include <stdio.h>
+
+
+struct WWQueueThreadState {
+	bool running;
+	bool stop;
+	WWQueueCallback task;
+	LPVOID arg;
+};
+
+DWORD WINAPI WindowsWorkQueueLoop(LPVOID arg) {
+	WWQueueThreadState *state = (WWQueueThreadState *)arg;
+	state->running = true;
+	while (!state->stop) {
+		if (state->task != NULL) {
+			state->task(state->arg);
+			delete state->arg;
+			state->task = NULL;
+		}
+		Sleep(1);
+	}
+	state->running = false;
+
+	return 0;
+}
+
+bool WindowsWorkQueue::init(int number_threads)
+{
+	if (number_threads == 0) number_threads = DEFAULT_THREAD_COUNT;
+	state = new WWQueueThreadState[number_threads];
+	for (int i = 0; i < number_threads; ++i) {
+		state[i].running = false;
+		state[i].stop = false;
+		state[i].task = NULL;
+	}
+	workers = new HANDLE[number_threads];
+	for (int i = 0; i < number_threads; ++i) {
+		workers[i] = CreateThread(NULL, 0, WindowsWorkQueueLoop, state + i, 0, NULL);
+		if (workers[i] == INVALID_HANDLE_VALUE)
+			return false;
+		while (!state[i].running)
+			Sleep(1);
+	}
+	this->number_threads = number_threads;
+	return true;
+}
+
+bool WindowsWorkQueue::submit(WWQueueCallback cb, LPVOID arg)
+{
+	int i;
+
+	for (i = 0; i < number_threads; ++i) {
+		if (state[i].task == NULL) {
+			state[i].arg = arg;
+			state[i].task = cb;
+			break;
+		}
+	}
+	if (i == number_threads)
+		return false;
+
+	return true;
+}
+
+void WindowsWorkQueue::stop()
+{
+	for (int i = 0; i < number_threads; ++i) {
+		state[i].stop = true;
+		while (state[i].running)
+			Sleep(1);
+	}
+}

--- a/daemons/gptp/windows/daemon_cl/work_queue.hpp
+++ b/daemons/gptp/windows/daemon_cl/work_queue.hpp
@@ -1,0 +1,74 @@
+/******************************************************************************
+
+Copyright (c) 2009-2015, Intel Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the Intel Corporation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+******************************************************************************/
+
+#ifndef WORK_QUEUE_HPP
+#define WORK_QUEUE_HPP
+
+#include <WTypesbase.h>
+
+#define DEFAULT_THREAD_COUNT (5)
+
+struct WWQueueThreadState;
+
+typedef void(*WWQueueCallback)(LPVOID arg);
+
+class WindowsWorkQueue
+{
+private:
+	HANDLE *workers;
+	WWQueueThreadState *state;
+	int number_threads;
+
+public:
+	/**
+	 * @brief initialize work queue
+	 * @param number_threads [in] number of threads (0 = default)
+	 * @return true on success
+	 */
+	bool init( int number_threads );
+
+	/**
+	 * @brief submit job to work queue
+	 * @param cb [in] function to call
+	 * @param arg [in] parameter provided to callback
+	 * @return true on success
+	 */
+	bool submit( WWQueueCallback cb, LPVOID arg );
+
+	/**
+	 * @brief stop work queue
+	 */
+	void stop();
+};
+
+#endif/*WORK_QUEUE_HPP*/

--- a/daemons/gptp/windows/named_pipe_test/named_pipe_test.cpp
+++ b/daemons/gptp/windows/named_pipe_test/named_pipe_test.cpp
@@ -60,7 +60,7 @@ int _tmain(int argc, _TCHAR* argv[])
     strcpy_s( pipename, 64, PIPE_PREFIX );
     strcat_s( pipename, 64-strlen(pipename), P802_1AS_PIPENAME );
     HANDLE pipe;
-	uint64_t tsc_frequency = getTSCFrequency( 1000 );
+	uint64_t tsc_frequency = getTSCFrequency( true );
 
    // Wait for Ctrl-C
     if( !SetConsoleCtrlHandler( ctrl_handler, true )) {


### PR DESCRIPTION
buildPTPMessage friend declarations and function definition now use
        CommonPort object
processMessage method in PTP message classes now use CommonPort argument
redundant documentation for buildPTPMessage and processMessage removed
        leaving only that in the base class
Add cast to addEventTimerLocked() call (CommonPort::processEvent)
	preventing Windows compiler warnings
Moved all message interval maintenance to CommonPort, also simiplifying
	Signal message processing
Divided FollowUp processing code into two functions for code received on
	an EtherPort or a WirelessPort (as a Vendor Extension)
Modified Windows daemon code to accept a wireless flags
Added Windows wireless adapter abstract class to implement a PROSet-like
	interface for Windows
Implemented an Intel specific Windows wireless adapter class tested on 8260
	hardware with driver version 19.50.1.6