### PR TITLE
Start PDelay calculation as fast as possible in Automotive Profile

### DIFF
--- a/daemons/gptp/common/ether_port.cpp
+++ b/daemons/gptp/common/ether_port.cpp
@@ -174,14 +174,8 @@ void EtherPort::startPDelay()
 			if( getPDelayInterval() !=
 			    PTPMessageSignalling::sigMsgInterval_NoSend)
 			{
-				long long unsigned int waitTime;
-				waitTime = ((long long)
-					    (pow((double)2,
-						 getPDelayInterval()) *
-					     1000000000.0));
-				waitTime = waitTime > EVENT_TIMER_GRANULARITY ? waitTime : EVENT_TIMER_GRANULARITY;
 				pdelay_started = true;
-				startPDelayIntervalTimer(waitTime);
+				startPDelayIntervalTimer(EVENT_TIMER_GRANULARITY);
 			}
 		}
 		else {


### PR DESCRIPTION
Trigger initial PDelay calculation without waiting full interval (def. 1 sec).
For Automotive Profile and fast initial Sync rate, we are losing that 1 sec.
due to discarded (not processed) Follow_up messages (delay = INVALID_LINKDELAY).