### PR TITLE
Introduce Libavtp

### DIFF
--- a/lib/libavtp/HACKING.md
+++ b/lib/libavtp/HACKING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+Before submitting your patch to review, make sure it doesn't break any unit
+test. See the following section for information about how to build and run
+the unit tests.
+
+Additionally, if your patch adds new APIs to libavtp, please also provide
+patches adding test cases that cover the new APIs.
+
+# Running Unit Tests
+
+Unit tests required libcmocka so make sure you have cmocka packages installed
+in your system.
+
+Run the following command to build and run all unit tests. Make sure the build
+system files are generated already, see section 'Build' in the README.md file
+for more information.
+
+```
+$ ninja -C build test
+```

--- a/lib/libavtp/HACKING.md
+++ b/lib/libavtp/HACKING.md
@@ -1,11 +1,23 @@
 # Contributing
 
-Before submitting your patch to review, make sure it doesn't break any unit
-test. See the following section for information about how to build and run
-the unit tests.
+If you have a bug fixed or added support for some AVTP feature, your patches
+are welcomed! In order to get your patches merged faster, please follow the
+guidelines:
 
-Additionally, if your patch adds new APIs to libavtp, please also provide
-patches adding test cases that cover the new APIs.
+* Before submitting your patch to review, make sure it doesn't break any unit
+test. See section 'Running Unit Tests' for information about how to build and
+run unit tests.
+
+* Besides the bugfix/feature itself, also provide unit test covering the code
+you're contributing. See section 'Code Coverage' to check how you can easily
+generate coverage reports and see where you need to work on to get your code
+covered.
+
+* If your patch adds new public APIs to libavtp, please also provide patches
+adding example applications (or modify an existing one if it makes sense)
+which demonstrate how to use the new APIs.
+
+* Make sure the author's name and email are set properly.
 
 # Running Unit Tests
 

--- a/lib/libavtp/HACKING.md
+++ b/lib/libavtp/HACKING.md
@@ -19,3 +19,20 @@ for more information.
 ```
 $ ninja -C build test
 ```
+
+# Code Coverage
+
+Meson build system provides some built-in code coverage support based on `lcov`
+so make sure you have this package installed on your system in order to
+generate coverage reports.
+
+To generate html reports run the following commands:
+
+```
+$ rm -rf build/
+$ meson build -Db_coverage=true
+$ ninja -C build/ test
+$ ninja -C build/ coverage-html
+```
+
+The coverage report can be found in build/meson-logs/coveragereport/ directory.

--- a/lib/libavtp/HACKING.md
+++ b/lib/libavtp/HACKING.md
@@ -4,6 +4,9 @@ If you have a bug fixed or added support for some AVTP feature, your patches
 are welcomed! In order to get your patches merged faster, please follow the
 guidelines:
 
+* Check if all patches are following the coding style from libavtp project. See
+section 'Coding Style' for more information.
+
 * Before submitting your patch to review, make sure it doesn't break any unit
 test. See section 'Running Unit Tests' for information about how to build and
 run unit tests.
@@ -18,6 +21,26 @@ adding example applications (or modify an existing one if it makes sense)
 which demonstrate how to use the new APIs.
 
 * Make sure the author's name and email are set properly.
+
+# Coding Style
+
+The coding style from libavtp is pretty much the same from Linux kernel
+described in https://www.kernel.org/doc/html/latest/process/coding-style.html.
+
+The style for line wrapping is to indent as far as possible to the right
+without hitting the 80 columns limit.
+
+Example:
+
+```
+/* Correct */
+int avtp_aaf_pdu_set(struct avtp_stream_pdu *pdu, enum avtp_aaf_field field,
+								uint64_t val)
+
+/* Wrong */
+int avtp_aaf_pdu_set(struct avtp_stream_pdu *pdu, enum avtp_aaf_field field,
+		     uint64_t val)
+```
 
 # Running Unit Tests
 

--- a/lib/libavtp/LICENSE
+++ b/lib/libavtp/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2017, Intel Corporation
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Intel Corporation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lib/libavtp/README.md
+++ b/lib/libavtp/README.md
@@ -37,3 +37,12 @@ AVTP protocol defines several AVTPDU type formats (see Table 6 from IEEE
 1722-2016 spec). Libavtp doesn't support all of them yet. The list of supported
 formarts is:
 * AAF (PCM encapsulation only)
+
+# Examples
+
+The `examples/` directory in the top-level directory provides example
+applications which demonstrate the libavtp functionalities. To build an
+example application run `$ ninja -C build <example name>`.
+
+Information about what exactly each example application does and how it works
+is provided in the beginning of the .c file from each application.

--- a/lib/libavtp/README.md
+++ b/lib/libavtp/README.md
@@ -1,0 +1,32 @@
+# About
+
+Open source implementation of Audio Video Transport Protocol (AVTP) specified
+in IEEE 1722-2016 spec.
+
+Libavtp is under BSD License. For more information see LICENSE file.
+
+# Build
+
+Before building libavtp make sure you have all the required software installed
+in your system. Below are the requirements and their tested versions:
+
+* Meson >= 0.43
+* Ninja >= 1.8.2
+
+The first step to build libavtp is to generate the build system files.
+
+```
+$ meson build
+```
+
+Then build libavtp by running the following command. The building artifacts
+will be created under the build/ in the top-level directory.
+
+```
+$ ninja -C build
+```
+
+To install libavtp on your system run:
+```
+$ sudo ninja -C build install
+```

--- a/lib/libavtp/README.md
+++ b/lib/libavtp/README.md
@@ -30,3 +30,10 @@ To install libavtp on your system run:
 ```
 $ sudo ninja -C build install
 ```
+
+# AVTP Formats Support
+
+AVTP protocol defines several AVTPDU type formats (see Table 6 from IEEE
+1722-2016 spec). Libavtp doesn't support all of them yet. The list of supported
+formarts is:
+* AAF (PCM encapsulation only)

--- a/lib/libavtp/examples/aaf-listener.c
+++ b/lib/libavtp/examples/aaf-listener.c
@@ -1,0 +1,536 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* AAF Listener example.
+ *
+ * This example implements a very simple AAF listener application which
+ * receives AFF packets from the network, retrieves the PCM samples, and
+ * writes them to stdout once the presentation time is reached.
+ *
+ * For simplicity, the example accepts only AAF packets with the following
+ * specification:
+ *    - Sample format: 16-bit little endian
+ *    - Sample rate: 48 kHz
+ *    - Number of channels: 2 (stereo)
+ *
+ * TSN stream parameters such as destination mac address are passed via
+ * command-line arguments. Run 'aaf-listener --help' for more information.
+ *
+ * This example relies on the system clock to schedule PCM samples for
+ * playback. So make sure the system clock is synchronized with the PTP
+ * Hardware Clock (PHC) from your NIC and that the PHC is synchronized with
+ * the PTP time from the network. For further information on how to synchronize
+ * those clocks see ptp4l(8) and phc2sys(8) man pages.
+ *
+ * The easiest way to use this example is combining it with 'aplay' tool
+ * provided by alsa-utils. 'aplay' reads a PCM stream from stdin and sends it
+ * to a ALSA playback device (e.g. your speaker). So, to play Audio from a TSN
+ * stream, you should do something like this:
+ *
+ * $ aaf-listener <args> | aplay -f dat -t raw -D <playback-device>
+ */
+
+#include <assert.h>
+#include <argp.h>
+#include <arpa/inet.h>
+#include <linux/if.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/queue.h>
+#include <sys/timerfd.h>
+#include <unistd.h>
+
+#include "avtp.h"
+#include "avtp_aaf.h"
+
+#define STREAM_ID		0xAABBCCDDEEFF0001
+#define SAMPLE_SIZE		2 /* Sample size in bytes. */
+#define NUM_CHANNELS		2
+#define DATA_LEN		(SAMPLE_SIZE * NUM_CHANNELS)
+#define PDU_SIZE		(sizeof(struct avtp_stream_pdu) + DATA_LEN)
+#define NSEC_PER_SEC		1000000000ULL
+
+struct sample_entry {
+	STAILQ_ENTRY(sample_entry) entries;
+
+	struct timespec tspec;
+	uint8_t pcm_sample[DATA_LEN];
+};
+
+static STAILQ_HEAD(sample_queue, sample_entry) samples;
+static char ifname[IFNAMSIZ];
+static uint8_t macaddr[ETH_ALEN];
+static uint8_t expected_seq;
+
+static struct argp_option options[] = {
+	{"dst-addr", 'd', "MACADDR", 0, "Stream Destination MAC address" },
+	{"ifname", 'i', "IFNAME", 0, "Network Interface" },
+	{ 0 }
+};
+
+static error_t parser(int key, char *arg, struct argp_state *state)
+{
+	int res;
+
+	switch (key) {
+	case 'd':
+		res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+					&macaddr[0], &macaddr[1], &macaddr[2],
+					&macaddr[3], &macaddr[4], &macaddr[5]);
+		if (res != 6) {
+			fprintf(stderr, "Invalid address\n");
+			exit(EXIT_FAILURE);
+		}
+
+		break;
+	case 'i':
+		strncpy(ifname, arg, sizeof(ifname) - 1);
+		break;
+	}
+
+	return 0;
+}
+
+static struct argp argp = { options, parser };
+
+static int arm_timer(int fd, struct timespec *tspec)
+{
+	int res;
+	struct itimerspec timer_spec = { 0 };
+
+	timer_spec.it_value.tv_sec = tspec->tv_sec;
+	timer_spec.it_value.tv_nsec = tspec->tv_nsec;
+
+	res = timerfd_settime(fd, TFD_TIMER_ABSTIME, &timer_spec, NULL);
+	if (res < 0) {
+		perror("Failed to set timer");
+		return -1;
+	}
+
+	return 0;
+}
+
+/* Schedule 'pcm_sample' to be presented at time specified by 'tspec'. */
+static int schedule_sample(int fd, struct timespec *tspec, uint8_t *pcm_sample)
+{
+	struct sample_entry *entry;
+
+	entry = malloc(sizeof(*entry));
+	if (!entry) {
+		fprintf(stderr, "Failed to allocate memory\n");
+		return -1;
+	}
+
+	entry->tspec.tv_sec = tspec->tv_sec;
+	entry->tspec.tv_nsec = tspec->tv_nsec;
+	memcpy(entry->pcm_sample, pcm_sample, DATA_LEN);
+
+	STAILQ_INSERT_TAIL(&samples, entry, entries);
+
+	/* If this was the first entry inserted onto the queue, we need to arm
+	 * the timer.
+	 */
+	if (STAILQ_FIRST(&samples) == entry) {
+		int res;
+
+		res = arm_timer(fd, tspec);
+		if (res < 0) {
+			STAILQ_REMOVE(&samples, entry, sample_entry, entries);
+			free(entry);
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+static int present_sample(uint8_t *pcm_sample)
+{
+	ssize_t n;
+
+	n = write(STDOUT_FILENO, pcm_sample, DATA_LEN);
+	if (n < 0 || n != DATA_LEN) {
+		perror("Failed to write()");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int setup_socket(void)
+{
+	int fd, res;
+	struct ifreq req;
+	struct packet_mreq mreq;
+
+	struct sockaddr_ll sk_addr = {
+		.sll_family = AF_PACKET,
+		.sll_protocol = htons(ETH_P_TSN),
+	};
+
+	fd = socket(AF_PACKET, SOCK_DGRAM, htons(ETH_P_TSN));
+	if (fd < 0) {
+		perror("Failed to open socket");
+		return -1;
+	}
+
+	snprintf(req.ifr_name, sizeof(req.ifr_name), "%s", ifname);
+	res = ioctl(fd, SIOCGIFINDEX, &req);
+	if (res < 0) {
+		perror("Failed to get interface index");
+		goto err;
+	}
+
+	sk_addr.sll_ifindex = req.ifr_ifindex;
+
+	res = bind(fd, (struct sockaddr *) &sk_addr, sizeof(sk_addr));
+	if (res < 0) {
+		perror("Couldn't bind() to interface");
+		goto err;
+	}
+
+	mreq.mr_ifindex = sk_addr.sll_ifindex;
+	mreq.mr_type = PACKET_MR_MULTICAST;
+	mreq.mr_alen = ETH_ALEN;
+	memcpy(&mreq.mr_address, macaddr, ETH_ALEN);
+
+	res = setsockopt(fd, SOL_PACKET, PACKET_ADD_MEMBERSHIP,
+					&mreq, sizeof(struct packet_mreq));
+	if (res < 0) {
+		perror("Couldn't set PACKET_ADD_MEMBERSHIP");
+		goto err;
+	}
+
+	return fd;
+
+err:
+	close(fd);
+	return -1;
+}
+
+static bool is_valid_packet(struct avtp_stream_pdu *pdu)
+{
+	struct avtp_common_pdu *common = (struct avtp_common_pdu *) pdu;
+	uint64_t val64;
+	uint32_t val32;
+	int res;
+
+	res = avtp_pdu_get(common, AVTP_FIELD_SUBTYPE, &val32);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get subtype field: %d\n", res);
+		return false;
+	}
+	if (val32 != AVTP_SUBTYPE_AAF) {
+		fprintf(stderr, "Subtype mismatch: expected %u, got %u\n",
+						AVTP_FIELD_SUBTYPE, val32);
+		return false;
+	}
+
+	res = avtp_pdu_get(common, AVTP_FIELD_VERSION, &val32);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get version field: %d\n", res);
+		return false;
+	}
+	if (val32 != 0) {
+		fprintf(stderr, "Version mismatch: expected %u, got %u\n",
+								0, val32);
+		return false;
+	}
+
+	res = avtp_aaf_pdu_get(pdu, AVTP_AAF_FIELD_TV, &val64);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get tv field: %d\n", res);
+		return false;
+	}
+	if (val64 != 1) {
+		fprintf(stderr, "tv mismatch: expected %u, got %lu\n",
+								1, val64);
+		return false;
+	}
+
+	res = avtp_aaf_pdu_get(pdu, AVTP_AAF_FIELD_SP, &val64);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get sp field: %d\n", res);
+		return false;
+	}
+	if (val64 != AVTP_AAF_PCM_SP_NORMAL) {
+		fprintf(stderr, "tv mismatch: expected %u, got %lu\n",
+								1, val64);
+		return false;
+	}
+
+	res = avtp_aaf_pdu_get(pdu, AVTP_AAF_FIELD_STREAM_ID, &val64);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get stream ID field: %d\n", res);
+		return false;
+	}
+	if (val64 != STREAM_ID) {
+		fprintf(stderr, "Stream ID mismatch: expected %lu, got %lu\n",
+							STREAM_ID, val64);
+		return false;
+	}
+
+	res = avtp_aaf_pdu_get(pdu, AVTP_AAF_FIELD_SEQ_NUM, &val64);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get sequence num field: %d\n", res);
+		return false;
+	}
+
+	if (val64 != expected_seq) {
+		/* If we have a sequence number mismatch, we simply log the
+		 * issue and continue to process the packet. We don't want to
+		 * invalidate it since it is a valid packet after all.
+		 */
+		fprintf(stderr, "Sequence number mismatch: expected %u, got %lu\n",
+							expected_seq, val64);
+		expected_seq = val64;
+	}
+
+	expected_seq++;
+
+	res = avtp_aaf_pdu_get(pdu, AVTP_AAF_FIELD_FORMAT, &val64);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get format field: %d\n", res);
+		return false;
+	}
+	if (val64 != AVTP_AAF_FORMAT_INT_16BIT) {
+		fprintf(stderr, "Format mismatch: expected %u, got %lu\n",
+					AVTP_AAF_FORMAT_INT_16BIT, val64);
+		return false;
+	}
+
+	res = avtp_aaf_pdu_get(pdu, AVTP_AAF_FIELD_NSR, &val64);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get sample rate field: %d\n", res);
+		return false;
+	}
+	if (val64 != AVTP_AAF_PCM_NSR_48KHZ) {
+		fprintf(stderr, "Sample rate mismatch: expected %u, got %lu",
+						AVTP_AAF_PCM_NSR_48KHZ, val64);
+		return false;
+	}
+
+	res = avtp_aaf_pdu_get(pdu, AVTP_AAF_FIELD_CHAN_PER_FRAME, &val64);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get channels field: %d\n", res);
+		return false;
+	}
+	if (val64 != NUM_CHANNELS) {
+		fprintf(stderr, "Channels mismatch: expected %u, got %lu\n",
+							NUM_CHANNELS, val64);
+		return false;
+	}
+
+	res = avtp_aaf_pdu_get(pdu, AVTP_AAF_FIELD_BIT_DEPTH, &val64);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get depth field: %d\n", res);
+		return false;
+	}
+	if (val64 != 16) {
+		fprintf(stderr, "Depth mismatch: expected %u, got %lu\n",
+								16, val64);
+		return false;
+	}
+
+	res = avtp_aaf_pdu_get(pdu, AVTP_AAF_FIELD_STREAM_DATA_LEN, &val64);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get data_len field: %d\n", res);
+		return false;
+	}
+	if (val64 != DATA_LEN) {
+		fprintf(stderr, "Data len mismatch: expected %u, got %lu\n",
+							DATA_LEN, val64);
+		return false;
+	}
+
+	return true;
+}
+
+static int get_presentation_time(struct avtp_stream_pdu *pdu,
+							struct timespec *tspec)
+{
+	int res;
+	uint64_t avtp_time, ptime, now;
+
+	res = avtp_aaf_pdu_get(pdu, AVTP_AAF_FIELD_TIMESTAMP, &avtp_time);
+	if (res < 0) {
+		fprintf(stderr, "Failed to get AVTP time from PDU\n");
+		return -1;
+	}
+
+	res = clock_gettime(CLOCK_REALTIME, tspec);
+	if (res < 0) {
+		perror("Failed to get time from PHC");
+		return -1;
+	}
+
+	now = (tspec->tv_sec * NSEC_PER_SEC) + tspec->tv_nsec;
+
+	/* The avtp_timestamp within AAF packet is the lower part (32
+	 * less-significant bits) from presentation time calculated by the
+	 * talker.
+	 */
+	ptime = (now & 0xFFFFFFFF00000000ULL) | avtp_time;
+
+	/* If 'ptime' is less than the 'now', it means the higher part
+	 * from 'ptime' needs to be incremented by 1 in order to recover the
+	 * presentation time set by the talker.
+	 */
+	if (ptime < now)
+		ptime += (1ULL << 32);
+
+	tspec->tv_sec = ptime / NSEC_PER_SEC;
+	tspec->tv_nsec = ptime % NSEC_PER_SEC;
+
+	return 0;
+}
+
+static int new_packet(int sk_fd, int timer_fd)
+{
+	int res;
+	ssize_t n;
+	struct timespec tspec;
+	struct avtp_stream_pdu *pdu = alloca(PDU_SIZE);
+
+	memset(pdu, 0, PDU_SIZE);
+
+	n = recv(sk_fd, pdu, PDU_SIZE, 0);
+	if (n < 0 || n != PDU_SIZE) {
+		perror("Failed to receive data");
+		return -1;
+	}
+
+	if (!is_valid_packet(pdu)) {
+		fprintf(stderr, "Dropping packet\n");
+		return 0;
+	}
+
+	res = get_presentation_time(pdu, &tspec);
+	if (res < 0)
+		return -1;
+
+	res = schedule_sample(timer_fd, &tspec, pdu->avtp_payload);
+	if (res < 0)
+		return -1;
+
+	return 0;
+}
+
+static int timeout(int fd)
+{
+	int res;
+	ssize_t n;
+	uint64_t expirations;
+	struct sample_entry *entry;
+
+	n = read(fd, &expirations, sizeof(uint64_t));
+	if (n < 0) {
+		perror("Failed to read timerfd");
+		return -1;
+	}
+
+	assert(expirations == 1);
+
+	entry = STAILQ_FIRST(&samples);
+	assert(entry != NULL);
+
+	res = present_sample(entry->pcm_sample);
+	if (res < 0)
+		return -1;
+
+	STAILQ_REMOVE_HEAD(&samples, entries);
+	free(entry);
+
+	if (!STAILQ_EMPTY(&samples)) {
+		entry = STAILQ_FIRST(&samples);
+
+		res = arm_timer(fd, &entry->tspec);
+		if (res < 0)
+			return -1;
+	}
+
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	int sk_fd, timer_fd, res;
+	struct pollfd fds[2];
+
+	argp_parse(&argp, argc, argv, 0, NULL, NULL);
+
+	STAILQ_INIT(&samples);
+
+	sk_fd = setup_socket();
+	if (sk_fd < 0)
+		return 1;
+
+	timer_fd = timerfd_create(CLOCK_REALTIME, 0);
+	if (timer_fd < 0) {
+		close(sk_fd);
+		return 1;
+	}
+
+	fds[0].fd = sk_fd;
+	fds[0].events = POLLIN;
+	fds[1].fd = timer_fd;
+	fds[1].events = POLLIN;
+
+	while (1) {
+		res = poll(fds, 2, -1);
+		if (res < 0) {
+			perror("Failed to poll() fds");
+			goto err;
+		}
+
+		if (fds[0].revents & POLLIN) {
+			res = new_packet(sk_fd, timer_fd);
+			if (res < 0)
+				goto err;
+		}
+
+		if (fds[1].revents & POLLIN) {
+			res = timeout(timer_fd);
+			if (res < 0)
+				goto err;
+		}
+	}
+
+	return 0;
+
+err:
+	close(sk_fd);
+	close(timer_fd);
+	return 1;
+}

--- a/lib/libavtp/examples/aaf-talker.c
+++ b/lib/libavtp/examples/aaf-talker.c
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* AAF Talker example.
+ *
+ * This example implements a very simple AAF talker application which reads
+ * a PCM stream from stdin, creates AAF packets and transmit them via the
+ * network.
+ *
+ * For simplicity, the example supports only one set of PCM parameters:
+ *    - Sample format: 16-bit little endian
+ *    - Sample rate: 48 kHz
+ *    - Number of channels: 2 (stereo)
+ *
+ * TSN stream parameters (e.g. destination mac address, traffic priority) are
+ * passed via command-line arguments. Run 'aaf-talker --help' for more
+ * information.
+ *
+ * In order to have this example working properly, make sure you have
+ * configured FQTSS feature from your NIC according (for further information
+ * see tc-cbs(8)). Also, this example relies on system clock to set the AVTP
+ * timestamp so make sure it is synchronized with the PTP Hardware Clock (PHC)
+ * from your NIC and that the PHC is synchronized with the network clock. For
+ * further information see ptp4l(8) and phc2sys(8).
+ *
+ * The easiest way to use this example is combining it with 'arecord' tool
+ * provided by alsa-utils. 'arecord' reads the PCM stream from a capture ALSA
+ * device (e.g. your microphone) and writes it to stdout. So to stream Audio
+ * captured from your mic to a TSN network you should do something like this:
+ *
+ * $ arecord -f dat -t raw -D <capture-device> | aaf-talker <args>
+ */
+
+#include <alloca.h>
+#include <argp.h>
+#include <arpa/inet.h>
+#include <linux/if.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "avtp.h"
+#include "avtp_aaf.h"
+
+#define STREAM_ID		0xAABBCCDDEEFF0001
+#define SAMPLE_SIZE		2 /* Sample size in bytes. */
+#define NUM_CHANNELS		2
+#define DATA_LEN		(SAMPLE_SIZE * NUM_CHANNELS)
+#define PDU_SIZE		(sizeof(struct avtp_stream_pdu) + DATA_LEN)
+#define NSEC_PER_SEC		1000000000ULL
+#define NSEC_PER_MSEC		1000000ULL
+
+static char ifname[IFNAMSIZ];
+static uint8_t macaddr[ETH_ALEN];
+static int priority = -1;
+static int max_transit_time;
+
+static struct argp_option options[] = {
+	{"dst-addr", 'd', "MACADDR", 0, "Stream Destination MAC address" },
+	{"ifname", 'i', "IFNAME", 0, "Network Interface" },
+	{"max-transit-time", 'm', "MSEC", 0, "Maximum Transit Time in ms" },
+	{"prio", 'p', "NUM", 0, "SO_PRIORITY to be set in socket" },
+	{ 0 }
+};
+
+static error_t parser(int key, char *arg, struct argp_state *state)
+{
+	int res;
+
+	switch (key) {
+	case 'd':
+		res = sscanf(arg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+					&macaddr[0], &macaddr[1], &macaddr[2],
+					&macaddr[3], &macaddr[4], &macaddr[5]);
+		if (res != 6) {
+			fprintf(stderr, "Invalid address\n");
+			exit(EXIT_FAILURE);
+		}
+
+		break;
+	case 'i':
+		strncpy(ifname, arg, sizeof(ifname) - 1);
+		break;
+	case 'm':
+		max_transit_time = atoi(arg);
+		break;
+	case 'p':
+		priority = atoi(arg);
+		break;
+	}
+
+	return 0;
+}
+
+static struct argp argp = { options, parser };
+
+static int setup_socket(void)
+{
+	int fd, res;
+
+	fd = socket(AF_PACKET, SOCK_DGRAM, htons(ETH_P_TSN));
+	if (fd < 0) {
+		perror("Failed to open socket");
+		return -1;
+	}
+
+	if (priority != -1) {
+		res = setsockopt(fd, SOL_SOCKET, SO_PRIORITY, &priority,
+							sizeof(priority));
+		if (res < 0) {
+			perror("Failed to set priority");
+			goto err;
+		}
+
+	}
+
+	return fd;
+
+err:
+	close(fd);
+	return -1;
+}
+
+static int calculate_avtp_time(uint32_t *avtp_time)
+{
+	int res;
+	struct timespec tspec;
+	uint64_t ptime;
+
+	res = clock_gettime(CLOCK_REALTIME, &tspec);
+	if (res < 0) {
+		perror("Failed to get time");
+		return -1;
+	}
+
+	ptime = (tspec.tv_sec * NSEC_PER_SEC) +
+			(max_transit_time * NSEC_PER_MSEC) + tspec.tv_nsec;
+
+	*avtp_time = ptime % (1ULL << 32);
+
+	return 0;
+}
+
+static int init_pdu(struct avtp_stream_pdu *pdu)
+{
+	int res;
+
+	res = avtp_aaf_pdu_init(pdu);
+	if (res < 0)
+		return -1;
+
+	res = avtp_aaf_pdu_set(pdu, AVTP_AAF_FIELD_TV, 1);
+	if (res < 0)
+		return -1;
+
+	res = avtp_aaf_pdu_set(pdu, AVTP_AAF_FIELD_STREAM_ID, STREAM_ID);
+	if (res < 0)
+		return -1;
+
+	res = avtp_aaf_pdu_set(pdu, AVTP_AAF_FIELD_FORMAT,
+						AVTP_AAF_FORMAT_INT_16BIT);
+	if (res < 0)
+		return -1;
+
+	res = avtp_aaf_pdu_set(pdu, AVTP_AAF_FIELD_NSR,
+						AVTP_AAF_PCM_NSR_48KHZ);
+	if (res < 0)
+		return -1;
+
+	res = avtp_aaf_pdu_set(pdu, AVTP_AAF_FIELD_CHAN_PER_FRAME,
+								NUM_CHANNELS);
+	if (res < 0)
+		return -1;
+
+	res = avtp_aaf_pdu_set(pdu, AVTP_AAF_FIELD_BIT_DEPTH, 16);
+	if (res < 0)
+		return -1;
+
+	res = avtp_aaf_pdu_set(pdu, AVTP_AAF_FIELD_STREAM_DATA_LEN, DATA_LEN);
+	if (res < 0)
+		return -1;
+
+	res = avtp_aaf_pdu_set(pdu, AVTP_AAF_FIELD_SP, AVTP_AAF_PCM_SP_NORMAL);
+	if (res < 0)
+		return -1;
+
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	int fd, res;
+	struct ifreq req;
+	struct sockaddr_ll sk_addr;
+	struct avtp_stream_pdu *pdu = alloca(PDU_SIZE);
+	uint8_t seq_num = 0;
+
+	argp_parse(&argp, argc, argv, 0, NULL, NULL);
+
+	fd = setup_socket();
+	if (fd < 0)
+		return 1;
+
+	snprintf(req.ifr_name, sizeof(req.ifr_name), "%s", ifname);
+	res = ioctl(fd, SIOCGIFINDEX, &req);
+	if (res < 0) {
+		perror("Failed to get interface index");
+		goto err;
+	}
+
+	sk_addr.sll_family = AF_PACKET;
+	sk_addr.sll_protocol = htons(ETH_P_TSN);
+	sk_addr.sll_halen = ETH_ALEN;
+	sk_addr.sll_ifindex = req.ifr_ifindex;
+	memcpy(&sk_addr.sll_addr, macaddr, ETH_ALEN);
+
+	res = init_pdu(pdu);
+	if (res < 0)
+		goto err;
+
+	while (1) {
+		ssize_t n;
+		uint32_t avtp_time;
+
+		memset(pdu->avtp_payload, 0, DATA_LEN);
+
+		n = read(STDIN_FILENO, pdu->avtp_payload, DATA_LEN);
+		if (n == 0)
+			break;
+
+		if (n != DATA_LEN) {
+			fprintf(stderr, "read %zd bytes, expected %d\n",
+								n, DATA_LEN);
+		}
+
+		res = calculate_avtp_time(&avtp_time);
+		if (res < 0) {
+			fprintf(stderr, "Failed to calculate avtp time\n");
+			goto err;
+		}
+
+		res = avtp_aaf_pdu_set(pdu, AVTP_AAF_FIELD_TIMESTAMP,
+								avtp_time);
+		if (res < 0)
+			goto err;
+
+		res = avtp_aaf_pdu_set(pdu, AVTP_AAF_FIELD_SEQ_NUM, seq_num++);
+		if (res < 0)
+			goto err;
+
+		n = sendto(fd, pdu, PDU_SIZE, 0,
+				(struct sockaddr *) &sk_addr, sizeof(sk_addr));
+		if (n < 0) {
+			perror("Failed to send data");
+			goto err;
+		}
+
+		if (n != PDU_SIZE) {
+			fprintf(stderr, "wrote %zd bytes, expected %zd\n",
+								n, PDU_SIZE);
+		}
+	}
+
+	close(fd);
+	return 0;
+
+err:
+	close(fd);
+	return 1;
+}

--- a/lib/libavtp/include/avtp.h
+++ b/lib/libavtp/include/avtp.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <errno.h>
+#include <stdint.h>
+
+/* AVTP subtypes values. For further information refer to section 4.4.3.2 from
+ * IEEE 1722-2016 spec.
+ */
+#define AVTP_SUBTYPE_61883_IIDC			0x00
+#define AVTP_SUBTYPE_MMA_STREAM			0x01
+#define AVTP_SUBTYPE_AAF			0x02
+#define AVTP_SUBTYPE_CVF			0x03
+#define AVTP_SUBTYPE_CRF			0x04
+#define AVTP_SUBTYPE_TSCF			0x05
+#define AVTP_SUBTYPE_SVF			0x06
+#define AVTP_SUBTYPE_RVF			0x07
+#define AVTP_SUBTYPE_AEF_CONTINUOUS		0x6E
+#define AVTP_SUBTYPE_VSF_STREAM			0x6F
+#define AVTP_SUBTYPE_EF_STREAM			0x7F
+#define AVTP_SUBTYPE_NTSCF			0x82
+#define AVTP_SUBTYPE_ESCF			0xEC
+#define AVTP_SUBTYPE_EECF			0xED
+#define AVTP_SUBTYPE_AEF_DISCRETE		0xEE
+#define AVTP_SUBTYPE_ADP			0xFA
+#define AVTP_SUBTYPE_AECP			0xFB
+#define AVTP_SUBTYPE_ACMP			0xFC
+#define AVTP_SUBTYPE_MAAP			0xFE
+#define AVTP_SUBTYPE_EF_CONTROL			0xFF
+
+/* XXX: Fields from PDU structs should not be read or written directly since
+ * they are encoded in Network order which may be different from the Host
+ * order (see section 3.4.1 from IEEE 1722-2016 spec for further information).
+ *
+ * Any read or write operation with PDU structs should be done via getter and
+ * setter APIs which handle byte order conversion.
+ */
+struct avtp_common_pdu {
+	uint32_t subtype_data;
+	uint8_t pdu_specific[0];
+} __attribute__ ((__packed__));
+
+enum avtp_field {
+	AVTP_FIELD_SUBTYPE,
+	AVTP_FIELD_VERSION,
+	AVTP_FIELD_MAX,
+};
+
+/* Get value from Common AVTPDU field.
+ * @pdu: Pointer to PDU struct.
+ * @field: PDU field to be retrieved.
+ * @val: Pointer to variable which the retrieved value should be saved.
+ *
+ * Returns:
+ *    0: Success.
+ *    -EINVAL: If any argument is invalid.
+ */
+int avtp_pdu_get(const struct avtp_common_pdu *pdu, enum avtp_field field,
+								uint32_t *val);
+
+/* Set value from Common AVTPDU field.
+ * @pdu: Pointer to PDU struct.
+ * @field: PDU field to be set.
+ * @val: Value to be set.
+ *
+ * Returns:
+ *    0: Success.
+ *    -EINVAL: If any argument is invalid.
+ */
+int avtp_pdu_set(struct avtp_common_pdu *pdu, enum avtp_field field,
+								uint32_t val);

--- a/lib/libavtp/include/avtp_aaf.h
+++ b/lib/libavtp/include/avtp_aaf.h
@@ -30,58 +30,50 @@
 #include <errno.h>
 #include <stdint.h>
 
-/* AVTP subtypes values. For further information refer to section 4.4.3.2 from
- * IEEE 1722-2016 spec.
- */
-#define AVTP_SUBTYPE_61883_IIDC			0x00
-#define AVTP_SUBTYPE_MMA_STREAM			0x01
-#define AVTP_SUBTYPE_AAF			0x02
-#define AVTP_SUBTYPE_CVF			0x03
-#define AVTP_SUBTYPE_CRF			0x04
-#define AVTP_SUBTYPE_TSCF			0x05
-#define AVTP_SUBTYPE_SVF			0x06
-#define AVTP_SUBTYPE_RVF			0x07
-#define AVTP_SUBTYPE_AEF_CONTINUOUS		0x6E
-#define AVTP_SUBTYPE_VSF_STREAM			0x6F
-#define AVTP_SUBTYPE_EF_STREAM			0x7F
-#define AVTP_SUBTYPE_NTSCF			0x82
-#define AVTP_SUBTYPE_ESCF			0xEC
-#define AVTP_SUBTYPE_EECF			0xED
-#define AVTP_SUBTYPE_AEF_DISCRETE		0xEE
-#define AVTP_SUBTYPE_ADP			0xFA
-#define AVTP_SUBTYPE_AECP			0xFB
-#define AVTP_SUBTYPE_ACMP			0xFC
-#define AVTP_SUBTYPE_MAAP			0xFE
-#define AVTP_SUBTYPE_EF_CONTROL			0xFF
+/* AAF PCM 'format' field values. */
+#define AVTP_AAF_FORMAT_USER			0x00
+#define AVTP_AAF_FORMAT_FLOAT_32BIT		0x01
+#define AVTP_AAF_FORMAT_INT_32BIT		0x02
+#define AVTP_AAF_FORMAT_INT_24BIT		0x03
+#define AVTP_AAF_FORMAT_INT_16BIT		0x04
+#define AVTP_AAF_FORMAT_AES3_32BIT		0x05
 
-/* XXX: Fields from PDU structs should not be read or written directly since
- * they are encoded in Network order which may be different from the Host
- * order (see section 3.4.1 from IEEE 1722-2016 spec for further information).
- *
- * Any read or write operation with PDU structs should be done via getter and
- * setter APIs which handle byte order conversion.
- */
-struct avtp_common_pdu {
-	uint32_t subtype_data;
-	uint8_t pdu_specific[0];
-} __attribute__ ((__packed__));
+/* AAF PCM 'nsr' (nominal sample rate) field values. */
+#define AVTP_AAF_PCM_NSR_USER			0x00
+#define AVTP_AAF_PCM_NSR_8KHZ			0x01
+#define AVTP_AAF_PCM_NSR_16KHZ			0x02
+#define AVTP_AAF_PCM_NSR_32KHZ			0x03
+#define AVTP_AAF_PCM_NSR_44_1KHZ		0x04
+#define AVTP_AAF_PCM_NSR_48KHZ			0x05
+#define AVTP_AAF_PCM_NSR_88_2KHZ		0x06
+#define AVTP_AAF_PCM_NSR_96KHZ			0x07
+#define AVTP_AAF_PCM_NSR_176_4KHZ		0x08
+#define AVTP_AAF_PCM_NSR_192KHZ			0x09
+#define AVTP_AAF_PCM_NSR_24KHZ			0x0A
 
-struct avtp_stream_pdu {
-	uint32_t subtype_data;
-	uint64_t stream_id;
-	uint32_t avtp_time;
-	uint32_t format_specific;
-	uint32_t packet_info;
-	uint8_t avtp_payload[0];
-} __attribute__ ((__packed__));
+/* AAF PCM 'sp' (sparse timestamp) field values. */
+#define AVTP_AAF_PCM_SP_NORMAL			0x00
+#define AVTP_AAF_PCM_SP_SPARSE			0x01
 
-enum avtp_field {
-	AVTP_FIELD_SUBTYPE,
-	AVTP_FIELD_VERSION,
-	AVTP_FIELD_MAX,
+enum avtp_aaf_field {
+	AVTP_AAF_FIELD_SV,
+	AVTP_AAF_FIELD_MR,
+	AVTP_AAF_FIELD_TV,
+	AVTP_AAF_FIELD_SEQ_NUM,
+	AVTP_AAF_FIELD_TU,
+	AVTP_AAF_FIELD_STREAM_ID,
+	AVTP_AAF_FIELD_TIMESTAMP,
+	AVTP_AAF_FIELD_FORMAT,
+	AVTP_AAF_FIELD_NSR,
+	AVTP_AAF_FIELD_CHAN_PER_FRAME,
+	AVTP_AAF_FIELD_BIT_DEPTH,
+	AVTP_AAF_FIELD_STREAM_DATA_LEN,
+	AVTP_AAF_FIELD_SP,
+	AVTP_AAF_FIELD_EVT,
+	AVTP_AAF_FIELD_MAX,
 };
 
-/* Get value from Common AVTPDU field.
+/* Get value from AAF AVTPDU field.
  * @pdu: Pointer to PDU struct.
  * @field: PDU field to be retrieved.
  * @val: Pointer to variable which the retrieved value should be saved.
@@ -90,10 +82,10 @@ enum avtp_field {
  *    0: Success.
  *    -EINVAL: If any argument is invalid.
  */
-int avtp_pdu_get(const struct avtp_common_pdu *pdu, enum avtp_field field,
-								uint32_t *val);
+int avtp_aaf_pdu_get(const struct avtp_stream_pdu *pdu,
+				enum avtp_aaf_field field, uint64_t *val);
 
-/* Set value from Common AVTPDU field.
+/* Set value from AAF AVTPDU field.
  * @pdu: Pointer to PDU struct.
  * @field: PDU field to be set.
  * @val: Value to be set.
@@ -102,5 +94,15 @@ int avtp_pdu_get(const struct avtp_common_pdu *pdu, enum avtp_field field,
  *    0: Success.
  *    -EINVAL: If any argument is invalid.
  */
-int avtp_pdu_set(struct avtp_common_pdu *pdu, enum avtp_field field,
-								uint32_t val);
+int avtp_aaf_pdu_set(struct avtp_stream_pdu *pdu, enum avtp_aaf_field field,
+								uint64_t val);
+
+/* Initialize AAF AVTPDU. All AVTPDU fields are initialized with zero except
+ * 'subtype' (which is set to AVTP_SUBTYPE_AAF) and 'sv' (which is set to 1).
+ * @pdu: Pointer to PDU struct.
+ *
+ * Return values:
+ *    0: Success.
+ *    -EINVAL: If any argument is invalid.
+ */
+int avtp_aaf_pdu_init(struct avtp_stream_pdu *pdu);

--- a/lib/libavtp/meson.build
+++ b/lib/libavtp/meson.build
@@ -40,3 +40,11 @@ test_aaf = executable(
 
 test('AVTP API', test_avtp)
 test('AAF API', test_aaf)
+
+executable(
+	'aaf-talker',
+	'examples/aaf-talker.c',
+	include_directories: include_directories('include'),
+	link_with: avtp_lib,
+	build_by_default: false,
+)

--- a/lib/libavtp/meson.build
+++ b/lib/libavtp/meson.build
@@ -29,4 +29,14 @@ test_avtp = executable(
 	build_by_default: false,
 )
 
+test_aaf = executable(
+	'test-aaf',
+	'unit/test-aaf.c',
+	include_directories: include_directories('include'),
+	link_with: avtp_lib,
+	dependencies: dependency('cmocka'),
+	build_by_default: false,
+)
+
 test('AVTP API', test_avtp)
+test('AAF API', test_aaf)

--- a/lib/libavtp/meson.build
+++ b/lib/libavtp/meson.build
@@ -7,9 +7,15 @@ project(
 
 library(
 	'avtp',
-	'src/avtp.c',
+	[
+	 'src/avtp.c',
+	 'src/avtp_aaf.c',
+	],
 	include_directories: include_directories('include'),
 	install: true,
 )
 
-install_headers('include/avtp.h')
+install_headers(
+	'include/avtp.h',
+	'include/avtp_aaf.h',
+)

--- a/lib/libavtp/meson.build
+++ b/lib/libavtp/meson.build
@@ -48,3 +48,11 @@ executable(
 	link_with: avtp_lib,
 	build_by_default: false,
 )
+
+executable(
+	'aaf-listener',
+	'examples/aaf-listener.c',
+	include_directories: include_directories('include'),
+	link_with: avtp_lib,
+	build_by_default: false,
+)

--- a/lib/libavtp/meson.build
+++ b/lib/libavtp/meson.build
@@ -5,7 +5,7 @@ project(
 	license: 'BSD-3-Clause',
 )
 
-library(
+avtp_lib = library(
 	'avtp',
 	[
 	 'src/avtp.c',
@@ -19,3 +19,14 @@ install_headers(
 	'include/avtp.h',
 	'include/avtp_aaf.h',
 )
+
+test_avtp = executable(
+	'test-avtp',
+	'unit/test-avtp.c',
+	include_directories: include_directories('include'),
+	link_with: avtp_lib,
+	dependencies: dependency('cmocka'),
+	build_by_default: false,
+)
+
+test('AVTP API', test_avtp)

--- a/lib/libavtp/meson.build
+++ b/lib/libavtp/meson.build
@@ -1,0 +1,15 @@
+project(
+	'libavtp',
+	'c',
+	version: '0.1',
+	license: 'BSD-3-Clause',
+)
+
+library(
+	'avtp',
+	'src/avtp.c',
+	include_directories: include_directories('include'),
+	install: true,
+)
+
+install_headers('include/avtp.h')

--- a/lib/libavtp/src/avtp.c
+++ b/lib/libavtp/src/avtp.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <arpa/inet.h>
+#include <stddef.h>
+
+#include "avtp.h"
+#include "util.h"
+
+#define SHIFT_SUBTYPE			(31 - 7)
+#define SHIFT_VERSION			(31 - 11)
+
+#define MASK_SUBTYPE			(BITMASK(8) << SHIFT_SUBTYPE)
+#define MASK_VERSION			(BITMASK(3) << SHIFT_VERSION)
+
+int avtp_pdu_get(const struct avtp_common_pdu *pdu, enum avtp_field field,
+								uint32_t *val)
+{
+	uint32_t bitmap, mask;
+	uint8_t shift;
+
+	if (!pdu || !val)
+		return -EINVAL;
+
+	switch (field) {
+	case AVTP_FIELD_SUBTYPE:
+		mask = MASK_SUBTYPE;
+		shift = SHIFT_SUBTYPE;
+		break;
+	case AVTP_FIELD_VERSION:
+		mask = MASK_VERSION;
+		shift = SHIFT_VERSION;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	bitmap = ntohl(pdu->subtype_data);
+
+	*val = BITMAP_GET_VALUE(bitmap, mask, shift);
+
+	return 0;
+}
+
+int avtp_pdu_set(struct avtp_common_pdu *pdu, enum avtp_field field,
+								uint32_t value)
+{
+	uint32_t bitmap, mask;
+	uint8_t shift;
+
+	if (!pdu)
+		return -EINVAL;
+
+	switch (field) {
+	case AVTP_FIELD_SUBTYPE:
+		mask = MASK_SUBTYPE;
+		shift = SHIFT_SUBTYPE;
+		break;
+	case AVTP_FIELD_VERSION:
+		mask = MASK_VERSION;
+		shift = SHIFT_VERSION;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	bitmap = ntohl(pdu->subtype_data);
+
+	BITMAP_SET_VALUE(bitmap, value, mask, shift);
+
+	pdu->subtype_data = htonl(bitmap);
+
+	return 0;
+}

--- a/lib/libavtp/src/avtp_aaf.c
+++ b/lib/libavtp/src/avtp_aaf.c
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <arpa/inet.h>
+#include <endian.h>
+#include <string.h>
+
+#include "avtp.h"
+#include "avtp_aaf.h"
+#include "util.h"
+
+#define SHIFT_SV			(31 - 8)
+#define SHIFT_MR			(31 - 12)
+#define SHIFT_TV			(31 - 15)
+#define SHIFT_SEQ_NUM			(31 - 23)
+#define SHIFT_FORMAT			(31 - 7)
+#define SHIFT_NSR			(31 - 11)
+#define SHIFT_CHAN_PER_FRAME		(31 - 23)
+#define SHIFT_STREAM_DATA_LEN		(31 - 15)
+#define SHIFT_SP			(31 - 19)
+#define SHIFT_EVT			(31 - 23)
+
+#define MASK_SV				(BITMASK(1) << SHIFT_SV)
+#define MASK_MR				(BITMASK(1) << SHIFT_MR)
+#define MASK_TV				(BITMASK(1) << SHIFT_TV)
+#define MASK_SEQ_NUM			(BITMASK(8) << SHIFT_SEQ_NUM)
+#define MASK_TU				(BITMASK(1))
+#define MASK_FORMAT			(BITMASK(8) << SHIFT_FORMAT)
+#define MASK_NSR			(BITMASK(4) << SHIFT_NSR)
+#define MASK_CHAN_PER_FRAME		(BITMASK(10) << SHIFT_CHAN_PER_FRAME)
+#define MASK_BIT_DEPTH			(BITMASK(8))
+#define MASK_STREAM_DATA_LEN		(BITMASK(16) << SHIFT_STREAM_DATA_LEN)
+#define MASK_SP				(BITMASK(1) << SHIFT_SP)
+#define MASK_EVT			(BITMASK(4) << SHIFT_EVT)
+
+static int get_field_value(const struct avtp_stream_pdu *pdu,
+				enum avtp_aaf_field field, uint64_t *val)
+{
+	uint32_t bitmap, mask;
+	uint8_t shift;
+
+	switch (field) {
+	case AVTP_AAF_FIELD_SV:
+		mask = MASK_SV;
+		shift = SHIFT_SV;
+		bitmap = ntohl(pdu->subtype_data);
+		break;
+	case AVTP_AAF_FIELD_MR:
+		mask = MASK_MR;
+		shift = SHIFT_MR;
+		bitmap = ntohl(pdu->subtype_data);
+		break;
+	case AVTP_AAF_FIELD_TV:
+		mask = MASK_TV;
+		shift = SHIFT_TV;
+		bitmap = ntohl(pdu->subtype_data);
+		break;
+	case AVTP_AAF_FIELD_SEQ_NUM:
+		mask = MASK_SEQ_NUM;
+		shift = SHIFT_SEQ_NUM;
+		bitmap = ntohl(pdu->subtype_data);
+		break;
+	case AVTP_AAF_FIELD_TU:
+		mask = MASK_TU;
+		shift = 0;
+		bitmap = ntohl(pdu->subtype_data);
+		break;
+	case AVTP_AAF_FIELD_FORMAT:
+		mask = MASK_FORMAT;
+		shift = SHIFT_FORMAT;
+		bitmap = ntohl(pdu->format_specific);
+		break;
+	case AVTP_AAF_FIELD_NSR:
+		mask = MASK_NSR;
+		shift = SHIFT_NSR;
+		bitmap = ntohl(pdu->format_specific);
+		break;
+	case AVTP_AAF_FIELD_CHAN_PER_FRAME:
+		mask = MASK_CHAN_PER_FRAME;
+		shift = SHIFT_CHAN_PER_FRAME;
+		bitmap = ntohl(pdu->format_specific);
+		break;
+	case AVTP_AAF_FIELD_BIT_DEPTH:
+		mask = MASK_BIT_DEPTH;
+		shift = 0;
+		bitmap = ntohl(pdu->format_specific);
+		break;
+	case AVTP_AAF_FIELD_STREAM_DATA_LEN:
+		mask = MASK_STREAM_DATA_LEN;
+		shift = SHIFT_STREAM_DATA_LEN;
+		bitmap = ntohl(pdu->packet_info);
+		break;
+	case AVTP_AAF_FIELD_SP:
+		mask = MASK_SP;
+		shift = SHIFT_SP;
+		bitmap = ntohl(pdu->packet_info);
+		break;
+	case AVTP_AAF_FIELD_EVT:
+		mask = MASK_EVT;
+		shift = SHIFT_EVT;
+		bitmap = ntohl(pdu->packet_info);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	*val = BITMAP_GET_VALUE(bitmap, mask, shift);
+
+	return 0;
+}
+
+int avtp_aaf_pdu_get(const struct avtp_stream_pdu *pdu,
+				enum avtp_aaf_field field, uint64_t *val)
+{
+	int res;
+
+	if (!pdu || !val)
+		return -EINVAL;
+
+	switch (field) {
+	case AVTP_AAF_FIELD_SV:
+	case AVTP_AAF_FIELD_MR:
+	case AVTP_AAF_FIELD_TV:
+	case AVTP_AAF_FIELD_SEQ_NUM:
+	case AVTP_AAF_FIELD_TU:
+	case AVTP_AAF_FIELD_FORMAT:
+	case AVTP_AAF_FIELD_NSR:
+	case AVTP_AAF_FIELD_CHAN_PER_FRAME:
+	case AVTP_AAF_FIELD_BIT_DEPTH:
+	case AVTP_AAF_FIELD_STREAM_DATA_LEN:
+	case AVTP_AAF_FIELD_SP:
+	case AVTP_AAF_FIELD_EVT:
+		res = get_field_value(pdu, field, val);
+		break;
+	case AVTP_AAF_FIELD_TIMESTAMP:
+		*val = ntohl(pdu->avtp_time);
+		res = 0;
+		break;
+	case AVTP_AAF_FIELD_STREAM_ID:
+		*val = be64toh(pdu->stream_id);
+		res = 0;
+		break;
+	default:
+		res = -EINVAL;
+		break;
+	}
+
+	return res;
+}
+
+static int set_field_value(struct avtp_stream_pdu *pdu,
+				enum avtp_aaf_field field, uint32_t val)
+{
+	uint32_t *ptr, bitmap, mask;
+	uint8_t shift;
+
+	switch (field) {
+	case AVTP_AAF_FIELD_SV:
+		mask = MASK_SV;
+		shift = SHIFT_SV;
+		ptr = &pdu->subtype_data;
+		break;
+	case AVTP_AAF_FIELD_MR:
+		mask = MASK_MR;
+		shift = SHIFT_MR;
+		ptr = &pdu->subtype_data;
+		break;
+	case AVTP_AAF_FIELD_TV:
+		mask = MASK_TV;
+		shift = SHIFT_TV;
+		ptr = &pdu->subtype_data;
+		break;
+	case AVTP_AAF_FIELD_SEQ_NUM:
+		mask = MASK_SEQ_NUM;
+		shift = SHIFT_SEQ_NUM;
+		ptr = &pdu->subtype_data;
+		break;
+	case AVTP_AAF_FIELD_TU:
+		mask = MASK_TU;
+		shift = 0;
+		ptr = &pdu->subtype_data;
+		break;
+	case AVTP_AAF_FIELD_FORMAT:
+		mask = MASK_FORMAT;
+		shift = SHIFT_FORMAT;
+		ptr = &pdu->format_specific;
+		break;
+	case AVTP_AAF_FIELD_NSR:
+		mask = MASK_NSR;
+		shift = SHIFT_NSR;
+		ptr = &pdu->format_specific;
+		break;
+	case AVTP_AAF_FIELD_CHAN_PER_FRAME:
+		mask = MASK_CHAN_PER_FRAME;
+		shift = SHIFT_CHAN_PER_FRAME;
+		ptr = &pdu->format_specific;
+		break;
+	case AVTP_AAF_FIELD_BIT_DEPTH:
+		mask = MASK_BIT_DEPTH;
+		shift = 0;
+		ptr = &pdu->format_specific;
+		break;
+	case AVTP_AAF_FIELD_STREAM_DATA_LEN:
+		mask = MASK_STREAM_DATA_LEN;
+		shift = SHIFT_STREAM_DATA_LEN;
+		ptr = &pdu->packet_info;
+		break;
+	case AVTP_AAF_FIELD_SP:
+		mask = MASK_SP;
+		shift = SHIFT_SP;
+		ptr = &pdu->packet_info;
+		break;
+	case AVTP_AAF_FIELD_EVT:
+		mask = MASK_EVT;
+		shift = SHIFT_EVT;
+		ptr = &pdu->packet_info;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	bitmap = ntohl(*ptr);
+
+	BITMAP_SET_VALUE(bitmap, val, mask, shift);
+
+	*ptr = htonl(bitmap);
+
+	return 0;
+}
+
+int avtp_aaf_pdu_set(struct avtp_stream_pdu *pdu, enum avtp_aaf_field field,
+								uint64_t val)
+{
+	int res;
+
+	if (!pdu)
+		return -EINVAL;
+
+	switch (field) {
+	case AVTP_AAF_FIELD_SV:
+	case AVTP_AAF_FIELD_MR:
+	case AVTP_AAF_FIELD_TV:
+	case AVTP_AAF_FIELD_SEQ_NUM:
+	case AVTP_AAF_FIELD_TU:
+	case AVTP_AAF_FIELD_FORMAT:
+	case AVTP_AAF_FIELD_NSR:
+	case AVTP_AAF_FIELD_CHAN_PER_FRAME:
+	case AVTP_AAF_FIELD_BIT_DEPTH:
+	case AVTP_AAF_FIELD_STREAM_DATA_LEN:
+	case AVTP_AAF_FIELD_SP:
+	case AVTP_AAF_FIELD_EVT:
+		res = set_field_value(pdu, field, val);
+		break;
+	case AVTP_AAF_FIELD_TIMESTAMP:
+		pdu->avtp_time = htonl(val);
+		res = 0;
+		break;
+	case AVTP_AAF_FIELD_STREAM_ID:
+		pdu->stream_id = htobe64(val);
+		res = 0;
+		break;
+	default:
+		res = -EINVAL;
+	}
+
+	return res;
+}
+
+int avtp_aaf_pdu_init(struct avtp_stream_pdu *pdu)
+{
+	int res;
+
+	if (!pdu)
+		return -EINVAL;
+
+	memset(pdu, 0, sizeof(struct avtp_stream_pdu));
+
+	res = avtp_pdu_set((struct avtp_common_pdu *) pdu, AVTP_FIELD_SUBTYPE,
+							AVTP_SUBTYPE_AAF);
+	if (res < 0)
+		return res;
+
+	res = avtp_aaf_pdu_set(pdu, AVTP_AAF_FIELD_SV, 1);
+	if (res < 0)
+		return res;
+
+	return 0;
+};

--- a/lib/libavtp/src/util.h
+++ b/lib/libavtp/src/util.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#define BIT(n)				(1UL << n)
+
+#define BITMASK(len)			(BIT(len) - 1)
+
+/* Get value from the bits within 'bitmap' represented by 'mask'. The 'mask'
+ * parameter must be a continuous bit mask (e.g. 0b00111000). This macro
+ * doesn't work with non-continuous bit masks (e.g. 0b00101001).
+ */
+#define BITMAP_GET_VALUE(bitmap, mask, shift) \
+			((bitmap & mask) >> shift)
+
+/* Set the value 'val' in the 'bitmap' variable at the position represented by
+ * 'mask'.
+ */
+#define BITMAP_SET_VALUE(bitmap, val, mask, shift) \
+			(bitmap = (bitmap & ~mask) | ((val << shift) & mask))

--- a/lib/libavtp/unit/test-aaf.c
+++ b/lib/libavtp/unit/test-aaf.c
@@ -1,0 +1,575 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <arpa/inet.h>
+
+#include "avtp.h"
+#include "avtp_aaf.h"
+
+static void aaf_get_field_null_pdu(void **state)
+{
+	int res;
+	uint64_t val = 1;
+
+	res = avtp_aaf_pdu_get(NULL, AVTP_AAF_FIELD_SV, &val);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void aaf_get_field_null_val(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_SV, NULL);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void aaf_get_field_invalid_field(void **state)
+{
+	int res;
+	uint64_t val = 1;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_MAX, &val);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void aaf_get_field_sv(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'sv' field to 1. */
+	pdu.subtype_data = htonl(0x00800000);
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_SV, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void aaf_get_field_mr(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'mr' field to 1. */
+	pdu.subtype_data = htonl(0x00080000);
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_MR, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void aaf_get_field_tv(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'tv' field to 1. */
+	pdu.subtype_data = htonl(0x00010000);
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_TV, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void aaf_get_field_seq_num(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'sequence_num' field to 0x55. */
+	pdu.subtype_data = htonl(0x00005500);
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_SEQ_NUM, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0x55);
+}
+
+static void aaf_get_field_tu(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'tu' field to 1. */
+	pdu.subtype_data = htonl(0x00000001);
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_TU, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 1);
+}
+
+static void aaf_get_field_stream_id(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'stream_id' field to 0xAABBCCDDEEFF0001. */
+	pdu.stream_id = htobe64(0xAABBCCDDEEFF0001);
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_STREAM_ID, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xAABBCCDDEEFF0001);
+}
+
+static void aaf_get_field_timestamp(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'avtp_timestamp' field to 0x80C0FFEE. */
+	pdu.avtp_time = htonl(0x80C0FFEE);
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_TIMESTAMP, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0x80C0FFEE);
+}
+
+static void aaf_get_field_format(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'format' field to AVTP_AAF_FORMAT_INT_16BIT. */
+	pdu.format_specific = htonl(0x04000000);
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_FORMAT, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == AVTP_AAF_FORMAT_INT_16BIT);
+}
+
+static void aaf_get_field_nsr(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'nsr' field to AVTP_AAF_PCM_NSR_48KHZ. */
+	pdu.format_specific = htonl(0x00500000);
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_NSR, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == AVTP_AAF_PCM_NSR_48KHZ);
+}
+
+static void aaf_get_field_chan(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'channels_per_frame' field to 0x2AA. */
+	pdu.format_specific = htonl(0x0002AA00);
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_CHAN_PER_FRAME, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0x2AA);
+}
+
+static void aaf_get_field_depth(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'bit_depth' field to 0xA5. */
+	pdu.format_specific = htonl(0x000000A5);
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_BIT_DEPTH, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xA5);
+}
+
+static void aaf_get_field_data_len(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'stream_data_length' field to 0xAAAA. */
+	pdu.packet_info = htonl(0xAAAA0000);
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_STREAM_DATA_LEN, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xAAAA);
+}
+
+static void aaf_get_field_sp(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'sp' field to AVTP_AAF_PCM_SP_SPARSE. */
+	pdu.packet_info = htonl(0x00001000);
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_SP, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == AVTP_AAF_PCM_SP_SPARSE);
+}
+
+static void aaf_get_field_evt(void **state)
+{
+	int res;
+	uint64_t val;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	/* Set 'evt' field to 0xA. */
+	pdu.packet_info = htonl(0x00000A00);
+
+	res = avtp_aaf_pdu_get(&pdu, AVTP_AAF_FIELD_EVT, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 0xA);
+}
+
+static void aaf_set_field_null_pdu(void **state)
+{
+	int res;
+
+	res = avtp_aaf_pdu_set(NULL, AVTP_AAF_FIELD_SV, 1);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void aaf_set_field_invalid_field(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_MAX, 1);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void aaf_set_field_sv(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_SV, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00800000);
+	assert_true(ntohl(pdu.stream_id) == 0);
+	assert_true(ntohl(pdu.avtp_time) == 0);
+	assert_true(ntohl(pdu.format_specific) == 0);
+	assert_true(ntohl(pdu.packet_info) == 0);
+}
+
+static void aaf_set_field_mr(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_MR, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00080000);
+	assert_true(ntohl(pdu.stream_id) == 0);
+	assert_true(ntohl(pdu.avtp_time) == 0);
+	assert_true(ntohl(pdu.format_specific) == 0);
+	assert_true(ntohl(pdu.packet_info) == 0);
+}
+
+static void aaf_set_field_tv(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_TV, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00010000);
+	assert_true(ntohl(pdu.stream_id) == 0);
+	assert_true(ntohl(pdu.avtp_time) == 0);
+	assert_true(ntohl(pdu.format_specific) == 0);
+	assert_true(ntohl(pdu.packet_info) == 0);
+}
+
+static void aaf_set_field_seq_num(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_SEQ_NUM, 0x55);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00005500);
+	assert_true(ntohl(pdu.stream_id) == 0);
+	assert_true(ntohl(pdu.avtp_time) == 0);
+	assert_true(ntohl(pdu.format_specific) == 0);
+	assert_true(ntohl(pdu.packet_info) == 0);
+}
+
+static void aaf_set_field_tu(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_TU, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00000001);
+	assert_true(ntohl(pdu.stream_id) == 0);
+	assert_true(ntohl(pdu.avtp_time) == 0);
+	assert_true(ntohl(pdu.format_specific) == 0);
+	assert_true(ntohl(pdu.packet_info) == 0);
+}
+
+static void aaf_set_field_stream_id(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_STREAM_ID,
+							0xAABBCCDDEEFF0001);
+
+	assert_int_equal(res, 0);
+	assert_true(be64toh(pdu.stream_id) == 0xAABBCCDDEEFF0001);
+	assert_true(ntohl(pdu.subtype_data) == 0);
+	assert_true(ntohl(pdu.avtp_time) == 0);
+	assert_true(ntohl(pdu.format_specific) == 0);
+	assert_true(ntohl(pdu.packet_info) == 0);
+}
+
+static void aaf_set_field_timestamp(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_TIMESTAMP, 0x80C0FFEE);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.avtp_time) == 0x80C0FFEE);
+	assert_true(ntohl(pdu.subtype_data) == 0);
+	assert_true(ntohl(pdu.stream_id) == 0);
+	assert_true(ntohl(pdu.format_specific) == 0);
+	assert_true(ntohl(pdu.packet_info) == 0);
+}
+
+static void aaf_set_field_format(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_FORMAT,
+						AVTP_AAF_FORMAT_INT_16BIT);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.format_specific) == 0x04000000);
+	assert_true(ntohl(pdu.subtype_data) == 0);
+	assert_true(ntohl(pdu.stream_id) == 0);
+	assert_true(ntohl(pdu.avtp_time) == 0);
+	assert_true(ntohl(pdu.packet_info) == 0);
+}
+
+static void aaf_set_field_nsr(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_NSR,
+						AVTP_AAF_PCM_NSR_48KHZ);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.format_specific) == 0x00500000);
+	assert_true(ntohl(pdu.subtype_data) == 0);
+	assert_true(ntohl(pdu.stream_id) == 0);
+	assert_true(ntohl(pdu.avtp_time) == 0);
+	assert_true(ntohl(pdu.packet_info) == 0);
+}
+
+static void aaf_set_field_chan(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_CHAN_PER_FRAME, 0x2AA);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.format_specific) == 0x0002AA00);
+	assert_true(ntohl(pdu.subtype_data) == 0);
+	assert_true(ntohl(pdu.stream_id) == 0);
+	assert_true(ntohl(pdu.avtp_time) == 0);
+	assert_true(ntohl(pdu.packet_info) == 0);
+}
+
+static void aaf_set_field_depth(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_BIT_DEPTH, 0xA5);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.format_specific) == 0x000000A5);
+	assert_true(ntohl(pdu.subtype_data) == 0);
+	assert_true(ntohl(pdu.stream_id) == 0);
+	assert_true(ntohl(pdu.avtp_time) == 0);
+	assert_true(ntohl(pdu.packet_info) == 0);
+}
+
+static void aaf_set_field_data_len(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_STREAM_DATA_LEN, 0xAAAA);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.packet_info) == 0xAAAA0000);
+	assert_true(ntohl(pdu.subtype_data) == 0);
+	assert_true(ntohl(pdu.stream_id) == 0);
+	assert_true(ntohl(pdu.avtp_time) == 0);
+	assert_true(ntohl(pdu.format_specific) == 0);
+}
+
+static void aaf_set_field_sp(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_SP, 1);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.packet_info) == 0x00001000);
+	assert_true(ntohl(pdu.subtype_data) == 0);
+	assert_true(ntohl(pdu.stream_id) == 0);
+	assert_true(ntohl(pdu.avtp_time) == 0);
+	assert_true(ntohl(pdu.format_specific) == 0);
+}
+
+static void aaf_set_field_evt(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu = { 0 };
+
+	res = avtp_aaf_pdu_set(&pdu, AVTP_AAF_FIELD_EVT, 0xA);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.packet_info) == 0x00000A00);
+	assert_true(ntohl(pdu.subtype_data) == 0);
+	assert_true(ntohl(pdu.stream_id) == 0);
+	assert_true(ntohl(pdu.avtp_time) == 0);
+	assert_true(ntohl(pdu.format_specific) == 0);
+}
+
+static void aaf_pdu_init_null_pdu(void **state)
+{
+	int res;
+
+	res = avtp_aaf_pdu_init(NULL);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void aaf_pdu_init(void **state)
+{
+	int res;
+	struct avtp_stream_pdu pdu;
+
+	res = avtp_aaf_pdu_init(&pdu);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x02800000);
+	assert_true(pdu.stream_id == 0);
+	assert_true(pdu.avtp_time == 0);
+	assert_true(pdu.format_specific == 0);
+	assert_true(pdu.packet_info == 0);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(aaf_get_field_null_pdu),
+		cmocka_unit_test(aaf_get_field_null_val),
+		cmocka_unit_test(aaf_get_field_invalid_field),
+		cmocka_unit_test(aaf_get_field_sv),
+		cmocka_unit_test(aaf_get_field_mr),
+		cmocka_unit_test(aaf_get_field_tv),
+		cmocka_unit_test(aaf_get_field_seq_num),
+		cmocka_unit_test(aaf_get_field_tu),
+		cmocka_unit_test(aaf_get_field_stream_id),
+		cmocka_unit_test(aaf_get_field_timestamp),
+		cmocka_unit_test(aaf_get_field_format),
+		cmocka_unit_test(aaf_get_field_nsr),
+		cmocka_unit_test(aaf_get_field_chan),
+		cmocka_unit_test(aaf_get_field_depth),
+		cmocka_unit_test(aaf_get_field_data_len),
+		cmocka_unit_test(aaf_get_field_sp),
+		cmocka_unit_test(aaf_get_field_evt),
+		cmocka_unit_test(aaf_set_field_null_pdu),
+		cmocka_unit_test(aaf_set_field_invalid_field),
+		cmocka_unit_test(aaf_set_field_sv),
+		cmocka_unit_test(aaf_set_field_mr),
+		cmocka_unit_test(aaf_set_field_tv),
+		cmocka_unit_test(aaf_set_field_seq_num),
+		cmocka_unit_test(aaf_set_field_tu),
+		cmocka_unit_test(aaf_set_field_stream_id),
+		cmocka_unit_test(aaf_set_field_timestamp),
+		cmocka_unit_test(aaf_set_field_format),
+		cmocka_unit_test(aaf_set_field_nsr),
+		cmocka_unit_test(aaf_set_field_chan),
+		cmocka_unit_test(aaf_set_field_depth),
+		cmocka_unit_test(aaf_set_field_data_len),
+		cmocka_unit_test(aaf_set_field_sp),
+		cmocka_unit_test(aaf_set_field_evt),
+		cmocka_unit_test(aaf_pdu_init_null_pdu),
+		cmocka_unit_test(aaf_pdu_init),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/lib/libavtp/unit/test-avtp.c
+++ b/lib/libavtp/unit/test-avtp.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of Intel Corporation nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <arpa/inet.h>
+
+#include "avtp.h"
+
+static void get_field_null_pdu(void **state)
+{
+	int res;
+	uint32_t val = AVTP_SUBTYPE_MAAP;
+
+	res = avtp_pdu_get(NULL, AVTP_FIELD_SUBTYPE, &val);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void get_field_null_val(void **state)
+{
+	int res;
+	struct avtp_common_pdu pdu = { 0 };
+
+	res = avtp_pdu_get(&pdu, AVTP_FIELD_SUBTYPE, NULL);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void get_field_invalid_field(void **state)
+{
+	int res;
+	uint32_t val = AVTP_SUBTYPE_MAAP;
+	struct avtp_common_pdu pdu = { 0 };
+
+	res = avtp_pdu_get(&pdu, AVTP_FIELD_MAX, &val);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void get_field_subtype(void **state)
+{
+	int res;
+	uint32_t val;
+	struct avtp_common_pdu pdu = { 0 };
+
+	/* Set 'subtype' field to 0xFE (AVTP_SUBTYPE_MAAP). */
+	pdu.subtype_data = htonl(0xFE000000);
+
+	res = avtp_pdu_get(&pdu, AVTP_FIELD_SUBTYPE, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == AVTP_SUBTYPE_MAAP);
+}
+
+static void get_field_version(void **state)
+{
+	int res;
+	uint32_t val;
+	struct avtp_common_pdu pdu = { 0 };
+
+	/* Set 'version' field to 5. */
+	pdu.subtype_data = htonl(0x00500000);
+
+	res = avtp_pdu_get(&pdu, AVTP_FIELD_VERSION, &val);
+
+	assert_int_equal(res, 0);
+	assert_true(val == 5);
+}
+
+static void set_field_null_pdu(void **state)
+{
+	int res;
+
+	res = avtp_pdu_set(NULL, AVTP_FIELD_SUBTYPE, AVTP_SUBTYPE_MAAP);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void set_field_invalid_field(void **state)
+{
+	int res;
+	struct avtp_common_pdu pdu = { 0 };
+
+	res = avtp_pdu_set(&pdu, AVTP_FIELD_MAX, 1);
+
+	assert_int_equal(res, -EINVAL);
+}
+
+static void set_field_subtype(void **state)
+{
+	int res;
+	struct avtp_common_pdu pdu = { 0 };
+
+	res = avtp_pdu_set(&pdu, AVTP_FIELD_SUBTYPE, AVTP_SUBTYPE_MAAP);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0xFE000000);
+}
+
+static void set_field_version(void **state)
+{
+	int res;
+	struct avtp_common_pdu pdu = { 0 };
+
+	res = avtp_pdu_set(&pdu, AVTP_FIELD_VERSION, 5);
+
+	assert_int_equal(res, 0);
+	assert_true(ntohl(pdu.subtype_data) == 0x00500000);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(get_field_null_pdu),
+		cmocka_unit_test(get_field_null_val),
+		cmocka_unit_test(get_field_invalid_field),
+		cmocka_unit_test(get_field_subtype),
+		cmocka_unit_test(get_field_version),
+		cmocka_unit_test(set_field_null_pdu),
+		cmocka_unit_test(set_field_invalid_field),
+		cmocka_unit_test(set_field_subtype),
+		cmocka_unit_test(set_field_version),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION

Hi all,

AVB applications/frameworks rely on AVTP protocol to transport audio, video, and control data from talkers to listeners. Due to the lack of a general purpose AVTP implementation, each application/framework implements its own version of a subset of AVTP so we end up having multiple and fragmented implementations of AVTP protocol that are not very reusable by new applications. That said, we created the libavtp project, an opensource, general purpose, standalone implementation of AVTP protocol, that we'd like to contribute to OpenAvnu.

The goal of libavtp is to provide a general purpose library that applications and frameworks can leverage to handle AVTP packetization. It defines packet structures, format field values and provides APIs to get/set packet fields. With libavtp, we converge all AVTP packetization-related efforts in one single project and benefit all other projects that use it.

Currently, libavtp supports only AVTP Audio Format (AAF). The infrastructure to extend it to support other formats such as Compressed Video Format (CVF) and Clock Reference Format (CRF) is already in place, and we plan to develop them in the open under OpenAvnu project.

General information and instructions on how to build libavtp are provided in the README.md file. Libavtp has unit tests for all public APIs, covering pretty much 100% of its source code. Instructions on how to run unit tests and generate coverage reports are provided in HACKING.md file.

Libavtp is under BSD-3-Clause License. For more information see LICENSE file.

Best regards,

Andre
