### PR TITLE
travis: Hook in libavtp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,21 @@ install:
   - sudo apt-get update -qq
   - sudo apt-get install -y libpcap-dev libpci-dev libsndfile1-dev libjack-dev linux-headers-4.4.0-75-generic
   - sudo apt-get install -y libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libasound2-dev
+  - sudo apt-get install -y python3-pip
+  - curl -L "https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip"  -o ninja-linux.zip
+  - sudo unzip ninja-linux.zip -d /usr/local/bin
+  - sudo chmod 755 /usr/local/bin/ninja
+  - sudo pip3 install meson
+  - curl -L "https://cmocka.org/files/1.1/cmocka-1.1.1.tar.xz" -o cmocka-1.1.1.tar.xz
+  - tar -xf cmocka-1.1.1.tar.xz
+  - pushd cmocka-1.1.1
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug ..
+  - make
+  - sudo make install
+  - popd
+  - sudo cp /usr/src/linux-headers-4.4.0-75/include/uapi/linux/if_ether.h /usr/include/linux
   - sudo cp /usr/src/linux-headers-4.4.0-75/include/uapi/linux/ethtool.h /usr/include/linux
   - sudo cp /usr/src/linux-headers-4.4.0-75/include/uapi/linux/ptp_clock.h /usr/include/linux
   - CMAKE_URL="https://cmake.org/files/v3.9/cmake-3.9.4-Linux-x86_64.tar.gz"

--- a/travis.sh
+++ b/travis.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -ev
+
+ROOT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
 make igb
 make lib
 make daemons_all
@@ -17,3 +20,6 @@ mkdir build
 cd build
 cmake ..
 make doc
+cd $ROOT_DIR
+CFLAGS=-Wno-missing-braces meson lib/libavtp/ lib/libavtp/build
+ninja -C lib/libavtp/build/ test aaf-talker aaf-listener


### PR DESCRIPTION
This patch hooks libavtp into travis in order to have the CI system
building libavtp and example applications, as well as running the unit
tests.

Libavtp dependencies are installed manually because the packages
provided by Ubuntu Trusty are very old versions and incompatible. Also,
likewise ethtool.h and ptp_clock.h, this patch copies the if_ether.h
header from linux-headers-4.4.0-75 directory to /usr/include since the
version provided by Trusty is very old and doesn't define the ETH_P_TSN
macro.

Finally, this patch sets CFLAGS=-Wno-missing-braces when building
libavtp in order to silent a warning generated by gcc. Travis is using a
very old gcc version (4.8) which wrongly warns about universal zero
initializer (more details about this on
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119).