### PR TITLE
libavtp: Add pkg-config support

### DIFF
--- a/lib/libavtp/meson.build
+++ b/lib/libavtp/meson.build
@@ -20,6 +20,15 @@ install_headers(
 	'include/avtp_aaf.h',
 )
 
+pkg = import('pkgconfig')
+pkg.generate(
+	name: 'avtp',
+	description: 'AVTP packetization library',
+	version: '0.1',
+	url: 'github.com/AVnu/OpenAvnu',
+	libraries: avtp_lib,
+)
+
 test_avtp = executable(
 	'test-avtp',
 	'unit/test-avtp.c',


### PR DESCRIPTION
This patch adds support for pkg-config in order to make it easier to
other projects to link against libavtp.

We leverage Meson builtin support for generating and installing the
.pc file.