### PR TITLE
Kernel update support

### DIFF
--- a/kmod/igb/igb.h
+++ b/kmod/igb/igb.h
@@ -92,6 +92,9 @@ struct igb_user_page {
 #include <linux/i2c-algo-bit.h>
 #endif /* HAVE_I2C_SUPPORT */
 
+#include <linux/miscdevice.h>
+typedef u64 cycle_t;
+
 /* Interrupt defines */
 #define IGB_START_ITR                    648 /* ~6000 ints/sec */
 #define IGB_4K_ITR                       980

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -214,7 +214,7 @@ static long igb_ioctl_file(struct file *file, unsigned int cmd,
 			   unsigned long arg);
 static void igb_vm_open(struct vm_area_struct *vma);
 static void igb_vm_close(struct vm_area_struct *vma);
-static int igb_vm_fault(struct vm_area_struct *area, struct vm_fault *fdata);
+static int igb_vm_fault(struct vm_fault *fdata);
 static int igb_mmap(struct file *file, struct vm_area_struct *vma);
 static ssize_t igb_read(struct file *file, char __user *buf, size_t count,
 			loff_t *pos);
@@ -1090,7 +1090,7 @@ static void igb_set_interrupt_capability(struct igb_adapter *adapter, bool msix)
 			for (i = 0; i < numvecs; i++)
 				adapter->msix_entries[i].entry = i;
 
-			err = pci_enable_msix(pdev,
+			err = pci_enable_msix_exact(pdev,
 					      adapter->msix_entries, numvecs);
 			if (err == 0)
 				break;
@@ -10709,7 +10709,7 @@ static void igb_vm_close(struct vm_area_struct *vma)
 {
 }
 
-static int igb_vm_fault(struct vm_area_struct *area, struct vm_fault *fdata)
+static int igb_vm_fault(struct vm_fault *fdata)
 {
 		return VM_FAULT_SIGBUS;
 }


### PR DESCRIPTION
Adding igb_avb support for kernel 4.13 (previously it caused compile errors):
a)  replacing pci_enable_msi as it's been officially removed from kernel sources
b) changing invocation of igb_vm_fault - API has changed and there is no need to pass vm_area_struct any more
c) including miscdevice.h in order to ensure that the compiler recognizes the igb_miscdev structure elements