### PR TITLE
Kernel update support

### DIFF
--- a/kmod/igb/igb.h
+++ b/kmod/igb/igb.h
@@ -92,6 +92,9 @@ struct igb_user_page {
 #include <linux/i2c-algo-bit.h>
 #endif /* HAVE_I2C_SUPPORT */
 
+#include <linux/miscdevice.h>
+typedef u64 cycle_t;
+
 /* Interrupt defines */
 #define IGB_START_ITR                    648 /* ~6000 ints/sec */
 #define IGB_4K_ITR                       980

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -214,7 +214,7 @@ static long igb_ioctl_file(struct file *file, unsigned int cmd,
 			   unsigned long arg);
 static void igb_vm_open(struct vm_area_struct *vma);
 static void igb_vm_close(struct vm_area_struct *vma);
-static int igb_vm_fault(struct vm_area_struct *area, struct vm_fault *fdata);
+static int igb_vm_fault(struct vm_fault *fdata);
 static int igb_mmap(struct file *file, struct vm_area_struct *vma);
 static ssize_t igb_read(struct file *file, char __user *buf, size_t count,
 			loff_t *pos);
@@ -1090,7 +1090,7 @@ static void igb_set_interrupt_capability(struct igb_adapter *adapter, bool msix)
 			for (i = 0; i < numvecs; i++)
 				adapter->msix_entries[i].entry = i;
 
-			err = pci_enable_msix(pdev,
+			err = pci_enable_msix_exact(pdev,
 					      adapter->msix_entries, numvecs);
 			if (err == 0)
 				break;
@@ -10709,7 +10709,7 @@ static void igb_vm_close(struct vm_area_struct *vma)
 {
 }
 
-static int igb_vm_fault(struct vm_area_struct *area, struct vm_fault *fdata)
+static int igb_vm_fault(struct vm_fault *fdata)
 {
 		return VM_FAULT_SIGBUS;
 }

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -214,7 +214,11 @@ static long igb_ioctl_file(struct file *file, unsigned int cmd,
 			   unsigned long arg);
 static void igb_vm_open(struct vm_area_struct *vma);
 static void igb_vm_close(struct vm_area_struct *vma);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0)
 static int igb_vm_fault(struct vm_fault *fdata);
+#else
+static int igb_vm_fault(struct vm_area_struct *area, struct vm_fault *fdata);
+#endif
 static int igb_mmap(struct file *file, struct vm_area_struct *vma);
 static ssize_t igb_read(struct file *file, char __user *buf, size_t count,
 			loff_t *pos);
@@ -1090,8 +1094,13 @@ static void igb_set_interrupt_capability(struct igb_adapter *adapter, bool msix)
 			for (i = 0; i < numvecs; i++)
 				adapter->msix_entries[i].entry = i;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 			err = pci_enable_msix_exact(pdev,
 					      adapter->msix_entries, numvecs);
+#else
+            err = pci_enable_msix(pdev,
+                            adapter->msix_entries, numvecs);
+#endif
 			if (err == 0)
 				break;
 		}
@@ -10708,8 +10717,11 @@ static void igb_vm_open(struct vm_area_struct *vma)
 static void igb_vm_close(struct vm_area_struct *vma)
 {
 }
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0)
 static int igb_vm_fault(struct vm_fault *fdata)
+#else
+static int igb_vm_fault(struct vm_area_struct *area, struct vm_fault *fdata)
+#endif
 {
 		return VM_FAULT_SIGBUS;
 }


### PR DESCRIPTION
Adding support for newer kernel versions and ensuring backward compatibility. Changes include:

a) support for removing vm_area_struct argument from kernel sources in versions 4.11.0 and higher
b) removal of pci_enable_msix method in kernel sources 4.12.0 or higher
c) including miscdevice.h so that the driver recognizes igb_miscdevice elements

This change resolves the problem of igb_avb driver causing compilation error in kernel versions higher than 4.10. It has been tested with several kernel versions (ranging from 4.4 till 4.14) in order to make sure that it does not introduce any regression.