### PR TITLE
Resolving Klocwork Static Code Analysis issues

### DIFF
--- a/kmod/igb/e1000_82575.c
+++ b/kmod/igb/e1000_82575.c
@@ -3218,8 +3218,6 @@ s32 e1000_read_i2c_byte_generic(struct e1000_hw *hw, u8 byte_offset,
 			goto fail;
 
 		status = e1000_clock_in_i2c_byte(hw, data);
-		if (status != E1000_SUCCESS)
-			goto fail;
 
 		status = e1000_clock_out_i2c_bit(hw, nack);
 		if (status != E1000_SUCCESS)

--- a/kmod/igb/e1000_82575.c
+++ b/kmod/igb/e1000_82575.c
@@ -98,10 +98,10 @@ static void e1000_clear_vfta_i350(struct e1000_hw *hw);
 
 static void e1000_i2c_start(struct e1000_hw *hw);
 static void e1000_i2c_stop(struct e1000_hw *hw);
-static s32 e1000_clock_in_i2c_byte(struct e1000_hw *hw, u8 *data);
+static void e1000_clock_in_i2c_byte(struct e1000_hw *hw, u8 *data);
 static s32 e1000_clock_out_i2c_byte(struct e1000_hw *hw, u8 data);
 static s32 e1000_get_i2c_ack(struct e1000_hw *hw);
-static s32 e1000_clock_in_i2c_bit(struct e1000_hw *hw, bool *data);
+static void e1000_clock_in_i2c_bit(struct e1000_hw *hw, bool *data);
 static s32 e1000_clock_out_i2c_bit(struct e1000_hw *hw, bool data);
 static void e1000_raise_i2c_clk(struct e1000_hw *hw, u32 *i2cctl);
 static void e1000_lower_i2c_clk(struct e1000_hw *hw, u32 *i2cctl);
@@ -3217,7 +3217,7 @@ s32 e1000_read_i2c_byte_generic(struct e1000_hw *hw, u8 byte_offset,
 		if (status != E1000_SUCCESS)
 			goto fail;
 
-		status = e1000_clock_in_i2c_byte(hw, data);
+		e1000_clock_in_i2c_byte(hw, data);
 
 		status = e1000_clock_out_i2c_bit(hw, nack);
 		if (status != E1000_SUCCESS)
@@ -3381,7 +3381,7 @@ static void e1000_i2c_stop(struct e1000_hw *hw)
  *
  *  Clocks in one byte data via I2C data/clock
  **/
-static s32 e1000_clock_in_i2c_byte(struct e1000_hw *hw, u8 *data)
+static void e1000_clock_in_i2c_byte(struct e1000_hw *hw, u8 *data)
 {
 	s32 i;
 	bool bit = 0;
@@ -3394,7 +3394,6 @@ static s32 e1000_clock_in_i2c_byte(struct e1000_hw *hw, u8 *data)
 		*data |= bit << i;
 	}
 
-	return E1000_SUCCESS;
 }
 
 /**
@@ -3483,7 +3482,7 @@ static s32 e1000_get_i2c_ack(struct e1000_hw *hw)
  *
  *  Clocks in one bit via I2C data/clock
  **/
-static s32 e1000_clock_in_i2c_bit(struct e1000_hw *hw, bool *data)
+static void e1000_clock_in_i2c_bit(struct e1000_hw *hw, bool *data)
 {
 	u32 i2cctl = E1000_READ_REG(hw, E1000_I2CPARAMS);
 
@@ -3502,7 +3501,6 @@ static s32 e1000_clock_in_i2c_bit(struct e1000_hw *hw, bool *data)
 	/* Minimum low period of clock is 4.7 us */
 	usec_delay(E1000_I2C_T_LOW);
 
-	return E1000_SUCCESS;
 }
 
 /**

--- a/kmod/igb/igb.h
+++ b/kmod/igb/igb.h
@@ -799,7 +799,7 @@ enum e1000_state_t {
 extern char igb_driver_name[];
 extern char igb_driver_version[];
 
-extern int igb_up(struct igb_adapter *);
+extern void igb_up(struct igb_adapter *);
 extern void igb_down(struct igb_adapter *);
 extern void igb_reinit_locked(struct igb_adapter *);
 extern void igb_reset(struct igb_adapter *);

--- a/kmod/igb/igb_ethtool.c
+++ b/kmod/igb/igb_ethtool.c
@@ -1528,7 +1528,7 @@ static void igb_loopback_cleanup(struct igb_adapter *adapter)
 	e1000_read_phy_reg(hw, PHY_CONTROL, &phy_reg);
 	if (phy_reg & MII_CR_LOOPBACK) {
 		phy_reg &= ~MII_CR_LOOPBACK;
-		if (hw->phy.type == I210_I_PHY_ID)
+		if (hw->phy.id == I210_I_PHY_ID)
 			e1000_write_phy_reg(hw, I347AT4_PAGE_SELECT, 0);
 		e1000_write_phy_reg(hw, PHY_CONTROL, phy_reg);
 		e1000_phy_commit(hw);
@@ -1714,9 +1714,9 @@ static int igb_loopback_test(struct igb_adapter *adapter, u64 *data)
 	if (*data)
 		goto out;
 	*data = igb_setup_loopback_test(adapter);
+	*data = igb_run_loopback_test(adapter);
 	if (*data)
 		goto err_loopback;
-	*data = igb_run_loopback_test(adapter);
 
 	igb_loopback_cleanup(adapter);
 
@@ -2141,7 +2141,7 @@ static void igb_get_strings(struct net_device *netdev, u32 stringset, u8 *data)
 
 	switch (stringset) {
 	case ETH_SS_TEST:
-		memcpy(data, *igb_gstrings_test,
+		memcpy(data, igb_gstrings_test,
 			IGB_TEST_LEN*ETH_GSTRING_LEN);
 		break;
 	case ETH_SS_STATS:

--- a/kmod/igb/igb_ethtool.c
+++ b/kmod/igb/igb_ethtool.c
@@ -1713,7 +1713,7 @@ static int igb_loopback_test(struct igb_adapter *adapter, u64 *data)
 	*data = igb_setup_desc_rings(adapter);
 	if (*data)
 		goto out;
-	*data = igb_setup_loopback_test(adapter);
+	igb_setup_loopback_test(adapter);
 	*data = igb_run_loopback_test(adapter);
 	if (*data)
 		goto err_loopback;

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -9615,10 +9615,7 @@ static void igb_io_resume(struct pci_dev *pdev)
 	}
 
 	if (netif_running(netdev)) {
-		if (igb_up(adapter)) {
-			dev_err(pci_dev_to_dev(pdev), "igb_up failed after reset\n");
-			return;
-		}
+		igb_up(adapter);
 	}
 
 	netif_device_attach(netdev);

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -1819,7 +1819,7 @@ static s32 igb_init_i2c(struct igb_adapter *adapter)
  * igb_up - Open the interface and prepare it to handle traffic
  * @adapter: board private structure
  **/
-int igb_up(struct igb_adapter *adapter)
+void igb_up(struct igb_adapter *adapter)
 {
 	struct e1000_hw *hw = &adapter->hw;
 	int i;
@@ -1863,7 +1863,6 @@ int igb_up(struct igb_adapter *adapter)
 	    (!hw->dev_spec._82575.eee_disable))
 		adapter->eee_advert = MDIO_EEE_100TX | MDIO_EEE_1000T;
 
-	return 0;
 }
 
 void igb_down(struct igb_adapter *adapter)

--- a/kmod/igb/igb_param.c
+++ b/kmod/igb/igb_param.c
@@ -539,7 +539,7 @@ void igb_check_options(struct igb_adapter *adapter)
 					 .max = (MAX_VMDQ
 					   - adapter->vfs_allocated_count)} }
 		};
-		if ((hw->mac.type != e1000_i210) ||
+		if ((hw->mac.type != e1000_i210) &&
 		    (hw->mac.type != e1000_i211)) {
 #ifdef module_param_array
 		if (num_VMDQ > bd) {


### PR DESCRIPTION
Recently Klocwork tool has been applied to the igb_avb driver code and as a consequence I'm pushing some resolved issues reported by that tool:

a) e1000_82575.c : e1000_clock_in_i2c_byte always returns "0" and other methods from the i2c API called within this method do the same. Therefore there is no sense in checking whether the returned value is !0 as it will never happen

b) igb_ethtool.c : 
     1. changing phy.type into phy.id as it was compared with the wrong define value
     2. igb_setup_loopback_test returns always 0 so there is no point I checking the output. The if   statement applied to igb_run loopback_test instead (more meaningful)
     3. Retrieve "*" operator not needed in case of memcpy and passing table igb_gstrings_test address

c) igb_main.c : igb_up returns always 0, so if(igb_up) will never occur

d) igb_param.c : wrong logic inside if statement. OR statement will not prevent from entering the code inside "if" in a proper way. AND is the desired one

