### PR TITLE
Port IGB_AVB to Linux v4.16-rc4

### DIFF
--- a/kmod/igb/e1000_osdep.h
+++ b/kmod/igb/e1000_osdep.h
@@ -90,7 +90,7 @@ struct e1000_hw;
 /* write operations, indexed using DWORDS */
 #define E1000_WRITE_REG(hw, reg, val) \
 do { \
-	u8 __iomem *hw_addr = ACCESS_ONCE((hw)->hw_addr); \
+	u8 __iomem *hw_addr = READ_ONCE((hw)->hw_addr); \
 	if (!E1000_REMOVED(hw_addr)) \
 		writel((val), &hw_addr[(reg)]); \
 } while (0)


### PR DESCRIPTION
This PR makes changes necessary to build the IGB_AVB kernel driver with Linux v4.16-rc4 (and hopefully 4.16, when it is released).

Changes:
- `ACCESS_ONCE` is no longer available, replaced with `READ_ONCE`
- `setup_timer` is no longer available, replaced with `timer_setup`
