### PR TITLE
travis: Stick to meson version 0.44

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - curl -L "https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip"  -o ninja-linux.zip
   - sudo unzip ninja-linux.zip -d /usr/local/bin
   - sudo chmod 755 /usr/local/bin/ninja
-  - sudo pip3 install meson
+  - sudo pip3 install meson==0.44.0
   - curl -L "https://cmocka.org/files/1.1/cmocka-1.1.1.tar.xz" -o cmocka-1.1.1.tar.xz
   - tar -xf cmocka-1.1.1.tar.xz
   - pushd cmocka-1.1.1


### PR DESCRIPTION
Meson 0.45 was released recently and it requires Python 3.5 which is not
installed in travis environment. This patch changes .travis.yml so
version 0.44 is installed instead.