### PR TITLE
Adding h264 timestamp field to AVTP h264 video header and fixed typo

### DIFF
--- a/lib/avtp_pipeline/map_h264/openavb_map_h264_pub.h
+++ b/lib/avtp_pipeline/map_h264/openavb_map_h264_pub.h
@@ -54,6 +54,8 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 typedef struct {
 	// Last fragment of frame flag.
 	bool lastPacket;		// For details see 1722a 9.4.3.1.1 M0 field
+	// The timestamp of h.264 NAL unit fragment.
+	U32 timestamp;			// For details see 1722-2016 8.5.3.1 h264_timestamp field
 } media_q_item_map_h264_pub_data_t;
 
 #endif  // OPENAVB_MAP_H264_PUB_H

--- a/lib/avtp_pipeline/platform/Linux/gst_al/gst_al.h
+++ b/lib/avtp_pipeline/platform/Linux/gst_al/gst_al.h
@@ -128,6 +128,14 @@ gboolean gst_al_rtp_buffer_get_marker(GstAlBuf *buf);
  */
 void gst_al_rtp_buffer_set_marker(GstAlBuf *buf, gboolean mark);
 /**
+ * \brief - gets a RTP buffer timestamp
+ *
+ * \param buf - a RTP buffer
+ *
+ * \return - a RTP buffer timestamp
+ */
+guint32 gst_al_rtp_buffer_get_timestamp(GstAlBuf *buf);
+/**
  * \brief - set a RTP buffer params
  *
  * \param buf - a RTP buffer

--- a/lib/avtp_pipeline/platform/Linux/gst_al/gst_al_10.c
+++ b/lib/avtp_pipeline/platform/Linux/gst_al/gst_al_10.c
@@ -185,6 +185,11 @@ void gst_al_rtp_buffer_set_marker(GstAlBuf *buf, gboolean mark)
 	gst_rtp_buffer_set_marker(&buf->m_rtpbuf, mark);
 }
 
+guint32 gst_al_rtp_buffer_get_timestamp(GstAlBuf *buf)
+{
+	return gst_rtp_buffer_get_timestamp(&buf->m_rtpbuf);
+}
+
 void gst_al_rtp_buffer_set_params(GstAlBuf *buf, gint ssrc,
                                   gint payload_type, gint version,
                                   gint sequence)

--- a/lib/avtp_pipeline/platform/Linux/intf_h264_gst/openavb_intf_h264_gst.c
+++ b/lib/avtp_pipeline/platform/Linux/intf_h264_gst/openavb_intf_h264_gst.c
@@ -340,6 +340,8 @@ bool openavbIntfH264RtpGstTxCB(media_q_t *pMediaQ)
 			{
 				((media_q_item_map_h264_pub_data_t *)pMediaQItem->pPubMapData)->lastPacket = FALSE;
 			}
+			((media_q_item_map_h264_pub_data_t *)pMediaQItem->pPubMapData)->timestamp =
+					gst_al_rtp_buffer_get_timestamp(txBuf);
 			openavbAvtpTimeSetToWallTime(pMediaQItem->pAvtpTime);
 			openavbMediaQHeadPush(pMediaQ);
 
@@ -545,7 +547,8 @@ bool openavbIntfH264RtpGstRxCB(media_q_t *pMediaQ)
 		}
 		memcpy(GST_AL_BUF_DATA(rxBuf), pMediaQItem->pPubData, pMediaQItem->dataLen);
 
-		GST_AL_BUFFER_TIMESTAMP(rxBuf) = GST_CLOCK_TIME_NONE;
+		//GST_AL_BUFFER_TIMESTAMP(rxBuf) = GST_CLOCK_TIME_NONE;
+		GST_AL_BUFFER_TIMESTAMP(rxBuf) = ((media_q_item_map_h264_pub_data_t *)pMediaQItem->pPubMapData)->timestamp;
 		GST_AL_BUFFER_DURATION(rxBuf) = GST_CLOCK_TIME_NONE;
 		if ( ((media_q_item_map_h264_pub_data_t *)pMediaQItem->pPubMapData)->lastPacket )
 		{


### PR DESCRIPTION
This commit adds support for H.264 video timestamp for talker and listener interface using GStreamer.
For details refer to IEEE 1722-2016 8.5.3.1 h264_timestamp field. 
