### PR TITLE
gptp : remove unnecessary sequence that try to delete pdelay request object.

### DIFF
--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1818,8 +1818,6 @@ void PTPMessagePathDelayRespFollowUp::processMessage
 	port->setPeerOffset( request_tx_timestamp, remote_req_rx_timestamp );
 
  abort:
-	delete req;
-	eport->setLastPDelayReq(NULL);
 	delete resp;
 	eport->setLastPDelayResp(NULL);
 


### PR DESCRIPTION
A object of pdelay_req is managed(create&delete) at ethe_port.
but it also could be deleted at a step for processing of pdelay_resp.

Those sequence should be deleted for some reasons below:
1. If pdelay_req is trigged in the middle of processing pdelay_resp, then 'null point exception' could be happened.
2. The available pdelay_req would(should) be kept until sending next pdelay_req. Becuase it is possible to receive correct pdelay_resp even after unexpected error at processing pdelay_rest.