### PR TITLE
Fix the dead lock when handling SYNC_RECEIPT_TIMEOUT_EXPIRES event

### DIFF
--- a/daemons/gptp/common/avbts_clock.hpp
+++ b/daemons/gptp/common/avbts_clock.hpp
@@ -162,7 +162,9 @@ private:
 
     OSLock *timerq_lock;
 
-	/**
+public:
+	
+    /**
 	 * @brief  Add a new event to the timer queue
 	 * @param  target EtherPort target
 	 * @param  e Event to be added
@@ -179,7 +181,7 @@ private:
 	 * @return void
 	 */
 	void deleteEventTimer( CommonPort *target, Event e );
-public:
+
   /**
    * @brief Instantiates a IEEE 1588 Clock
    * @param forceOrdinarySlave Forces it to be an ordinary slave

--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -298,8 +298,8 @@ void CommonPort::startSyncReceiptTimer
 {
 	clock->getTimerQLock();
 	syncReceiptTimerLock->lock();
-	clock->deleteEventTimerLocked( this, SYNC_RECEIPT_TIMEOUT_EXPIRES );
-	clock->addEventTimerLocked
+	clock->deleteEventTimer( this, SYNC_RECEIPT_TIMEOUT_EXPIRES );
+	clock->addEventTimer
 		( this, SYNC_RECEIPT_TIMEOUT_EXPIRES, waitTime );
 	syncReceiptTimerLock->unlock();
 	clock->putTimerQLock();
@@ -309,7 +309,7 @@ void CommonPort::stopSyncReceiptTimer( void )
 {
 	clock->getTimerQLock();
 	syncReceiptTimerLock->lock();
-	clock->deleteEventTimerLocked( this, SYNC_RECEIPT_TIMEOUT_EXPIRES );
+	clock->deleteEventTimer( this, SYNC_RECEIPT_TIMEOUT_EXPIRES );
 	syncReceiptTimerLock->unlock();
 	clock->putTimerQLock();
 }

--- a/daemons/gptp/common/common_port.cpp
+++ b/daemons/gptp/common/common_port.cpp
@@ -296,18 +296,22 @@ bool CommonPort::restoreSerializedState
 void CommonPort::startSyncReceiptTimer
 ( long long unsigned int waitTime )
 {
+	clock->getTimerQLock();
 	syncReceiptTimerLock->lock();
 	clock->deleteEventTimerLocked( this, SYNC_RECEIPT_TIMEOUT_EXPIRES );
 	clock->addEventTimerLocked
 		( this, SYNC_RECEIPT_TIMEOUT_EXPIRES, waitTime );
 	syncReceiptTimerLock->unlock();
+	clock->putTimerQLock();
 }
 
 void CommonPort::stopSyncReceiptTimer( void )
 {
+	clock->getTimerQLock();
 	syncReceiptTimerLock->lock();
 	clock->deleteEventTimerLocked( this, SYNC_RECEIPT_TIMEOUT_EXPIRES );
 	syncReceiptTimerLock->unlock();
+	clock->putTimerQLock();
 }
 
 void CommonPort::startSyncIntervalTimer


### PR DESCRIPTION
This is to fix issue #776 by adding timer queue lock in startSyncReceiptTimer and stopSyncReceiptTimer.