### PR TITLE
gptp: Add monotonic raw clock option

### DIFF
--- a/daemons/gptp/common/common_tstamper.hpp
+++ b/daemons/gptp/common/common_tstamper.hpp
@@ -73,6 +73,15 @@ public:
 	}
 
 	/**
+	 * @brief  Sets system clock descriptor
+	 * @param  system_clock_desc name of local clock
+	 * @return false if unimplemented
+	 */
+	virtual bool HWTimestamper_setsystemclock
+	( const char *system_clock_desc )
+	{ return false; }
+
+	/**
 	 * @brief  Adjusts the hardware clock frequency
 	 * @param  frequency_offset Frequency offset
 	 * @return false

--- a/daemons/gptp/common/gptp_cfg.cpp
+++ b/daemons/gptp/common/gptp_cfg.cpp
@@ -52,6 +52,7 @@ uint32_t findSpeedByName( const char *name, const char **end );
 
 GptpIniParser::GptpIniParser(std::string filename)
 {
+    _config.systemClockDesc[0] = '\0';
     _error = ini_parse(filename.c_str(), iniCallBack, this);
 }
 
@@ -84,6 +85,16 @@ int GptpIniParser::iniCallBack(void *user, const char *section, const char *name
                 valOK = true;
                 parser->_config.priority1 = p1;
             }
+        }
+    }
+    else if( parseMatch(section, "clock") )
+    {
+        if( parseMatch(name, "SystemClock") )
+        {
+		valOK = true;
+		strncpy( parser->_config.systemClockDesc, value,
+			 MAX_CLOCK_DESC_LEN );
+		parser->_config.systemClockDesc[MAX_CLOCK_DESC_LEN] = '\0';
         }
     }
     else if( parseMatch(section, "port") )

--- a/daemons/gptp/common/gptp_cfg.hpp
+++ b/daemons/gptp/common/gptp_cfg.hpp
@@ -66,23 +66,23 @@ class GptpIniParser
          */
         typedef struct
         {
-            /*ptp data set*/
-            unsigned char priority1;
+		/*ptp data set*/
+		unsigned char priority1;
 
 		/* Clock data set */
 		char systemClockDesc[MAX_CLOCK_DESC_LEN+1];
 
-            /*port data set*/
-            unsigned int announceReceiptTimeout;
-            unsigned int syncReceiptTimeout;
-            unsigned int syncReceiptThresh;		//!< Number of wrong sync messages that will trigger a switch to master
-            int64_t neighborPropDelayThresh;
-            unsigned int seqIdAsCapableThresh;
-            uint16_t lostPdelayRespThresh;
-            PortState port_state;
+		/*port data set*/
+		unsigned int announceReceiptTimeout;
+		unsigned int syncReceiptTimeout;
+		unsigned int syncReceiptThresh; //!< Number of wrong sync messages that will trigger a switch to master
+		int64_t neighborPropDelayThresh;
+		unsigned int seqIdAsCapableThresh;
+		uint16_t lostPdelayRespThresh;
+		PortState port_state;
 
-            /*ethernet adapter data set*/
-	    std::string ifname;
+		/*ethernet adapter data set*/
+		std::string ifname;
 		phy_delay_map_t phy_delay;
         } gptp_cfg_t;
 

--- a/daemons/gptp/common/gptp_cfg.hpp
+++ b/daemons/gptp/common/gptp_cfg.hpp
@@ -45,6 +45,7 @@ const uint32_t LINKSPEED_2_5G =		2500000;
 const uint32_t LINKSPEED_1G =		1000000;
 const uint32_t LINKSPEED_100MB =	100000;
 const uint32_t INVALID_LINKSPEED =	UINT_MAX;
+const uint8_t  MAX_CLOCK_DESC_LEN =	64;
 
 /**
  * @brief Returns name given numeric link speed
@@ -67,6 +68,9 @@ class GptpIniParser
         {
             /*ptp data set*/
             unsigned char priority1;
+
+		/* Clock data set */
+		char systemClockDesc[MAX_CLOCK_DESC_LEN+1];
 
             /*port data set*/
             unsigned int announceReceiptTimeout;
@@ -92,6 +96,15 @@ class GptpIniParser
          * @return Parser Error
          */
         int parserError(void);
+
+	/**
+	 * @brief Read SystemClock description
+	 * @return pointer to c-string representing system clock
+	 */
+	const char *getSystemClockDesc(void)
+	{
+		return _config.systemClockDesc;
+	}
 
         /**
          * @brief  Reads priority1 config value

--- a/daemons/gptp/gptp_cfg.ini
+++ b/daemons/gptp/gptp_cfg.ini
@@ -6,6 +6,14 @@
 # The lower the number, the higher the priority for the BMCA.
 priority1 = 248
 
+# Clock option to specify system clock type
+# Currently, Linux only. Options are MonotonicRaw and Realtime.
+# Realtime works on all network interfaces. MonotonicRaw is available on
+# interfaces that support it.
+
+#[clock]
+#SystemClock = MonotonicRaw
+
 [port]
 
 # TODO

--- a/daemons/gptp/linux/build/Makefile
+++ b/daemons/gptp/linux/build/Makefile
@@ -39,8 +39,8 @@ CFLAGS_G = -Wall -g -I. -I../../common -I../src \
 PRECISE_TIME_TEST = "\#include <linux/ptp_clock.h>\\n\
 \#ifdef PTP_SYS_OFFSET_PRECISE\\nint main(){return 0;}\\n\#endif"
 
-HAS_PRECISE_TIME = $(shell echo $(PRECISE_TIME_TEST) | $(CC) -xc - \
--I$(ALTERNATE_LINUX_INCPATH) -o /dev/null > /dev/null 2>&1 ; echo $$?)
+HAS_PRECISE_TIME = $(shell /bin/echo -e $(PRECISE_TIME_TEST) | $(CC) -xc - \
+-I$(ALTERNATE_LINUX_INCPATH); echo $$?)
 
 ifeq ($(HAS_PRECISE_TIME),0)
        CFLAGS_G += -DPTP_HW_CROSSTSTAMP

--- a/daemons/gptp/linux/src/daemon_cl.cpp
+++ b/daemons/gptp/linux/src/daemon_cl.cpp
@@ -150,6 +150,7 @@ int main(int argc, char **argv)
 	LinuxIPCArg *ipc_arg = NULL;
 	bool use_config_file = false;
 	char config_file_path[512];
+	const char *systemClockDesc = NULL;
 	memset(config_file_path, 0, 512);
 
 	GPTPPersist *pGPTPPersist = NULL;
@@ -424,6 +425,11 @@ int main(int argc, char **argv)
 			portInit.syncReceiptThreshold =
 				iniParser.getSyncReceiptThresh();
 
+			if( strnlen( iniParser.getSystemClockDesc(),
+				     MAX_CLOCK_DESC_LEN ) != 0 )
+				systemClockDesc =
+					iniParser.getSystemClockDesc();
+
 			/*Only overwrites phy_delay default values if not input_delay switch enabled*/
 			if(!input_delay)
 			{
@@ -431,6 +437,14 @@ int main(int argc, char **argv)
 			}
 		}
 
+	}
+
+	if( systemClockDesc != NULL )
+	{
+		if( timestamper->HWTimestamper_setsystemclock
+		    ( systemClockDesc ))
+			GPTP_LOG_INFO
+				( "Using system Clock: %s", systemClockDesc );
 	}
 
 	pPort = new EtherPort(&portInit);

--- a/daemons/gptp/linux/src/linux_hal_generic.hpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.hpp
@@ -67,10 +67,21 @@ private:
 #endif
 
 	TicketingLock *net_lock;
+	clockid_t system_clockid;
 
 #ifdef WITH_IGBLIB
 	LinuxTimestamperIGBPrivate_t igb_private;
 #endif
+
+	struct clock_map_t
+	{
+		clockid_t clockid;
+		const char *clock_name;
+	};
+
+	static clock_map_t system_clock_map[];
+
+	const char *getClockNameFromId( clockid_t clockid ) const;
 
 public:
 	/**
@@ -107,6 +118,9 @@ public:
 	 * @return void
 	 */
 	virtual void HWTimestamper_reset();
+
+	virtual bool HWTimestamper_setsystemclock
+	( const char *system_clock_desc );
 
 	/**
 	 * @brief  Inserts a new timestamp to the beginning of the


### PR DESCRIPTION
Timestamp clocks that implement the PTP_SYS_OFFSET_PRECISE ioctl return
 cross-timestamps with respect to monotonic raw and realtime
Add configuration file option allowing clock selection for system/local
 clock relation

The default clock type is Realtime which is equivalent to the
 CLOCK_REALTIME option to clock_gettime
Optionally, MonotonicRaw (equivalent to CLOCK_MONOTONIC_RAW) can be
 specified in the gPTP daemon configuration file:

[clock]

SystemClock = MonotonicRaw

Fixed Makefile issue where some shell configurations use built-in 'echo'
 and others don't
Forces all to use /bin/echo