### PR TITLE
fix image file doesn't show for asciidoc generation on AVnu_gPTP_Code…

### DIFF
--- a/documents/design/AVnu_gPTP_Code.asciidoc
+++ b/documents/design/AVnu_gPTP_Code.asciidoc
@@ -1,7 +1,7 @@
 = AVnu gPTP Code
 :toc:
 :toc-placement!:
-:repo: https://github.com/AVnu/Open-AVB/blob
+:repo: https://raw.githubusercontent.com/AVnu/OpenAvnu
 :img: {repo}/gh-pages/images/ptp
 
 toc::[]


### PR DESCRIPTION
….asciidoc

use following command to generate html5 format doc.
zhouxiang@wt-wlw-062:~/github/OpenAvnu_feishengfei/documents/design$ asciidoc -b html5 -a icons -a toc2 -a theme=flask AVnu_gPTP_Code.asciidoc