### PR TITLE
kmod/igb: Fix build by disabling -fPIC

### DIFF
--- a/kmod/igb/Makefile
+++ b/kmod/igb/Makefile
@@ -173,6 +173,8 @@ EXTRA_CFLAGS += $(shell [ -f $(KSRC)/include/linux/modversions.h ] && \
             echo "-DMODVERSIONS -DEXPORT_SYMTAB \
                   -include $(KSRC)/include/linux/modversions.h")
 
+EXTRA_CFLAGS += -fno-PIC
+
 EXTRA_CFLAGS += $(CFLAGS_EXTRA)
 
 RHC := $(KSRC)/include/linux/rhconfig.h


### PR DESCRIPTION
On recent distros with recent versions of gcc, the Makefile fails on
line 189 with:

cc1: error: code model kernel does not support PIC mode

Add -fno-PIC to our the EXTRA_CFLAGS to avoid that.

Signed-off-by: Jesus Sanchez-Palencia <jesus.sanchez-palencia@intel.com>