### PR TITLE
gptp: Fix error logging for event pkt without timestamp

### DIFF
--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -154,8 +154,8 @@ PTPMessageCommon *buildPTPMessage
 			char err_msg[HWTIMESTAMPER_EXTENDED_MESSAGE_SIZE];
 			port->getExtendedError(err_msg);
 			GPTP_LOG_ERROR
-			    ("*** Received an event packet but cannot retrieve timestamp, discarding. messageType=%u,error=%d\n%s",
-			     messageType, ts_good, msg);
+			    ("*** Received an event packet but cannot retrieve timestamp, discarding. messageType=%u,error=%d\t%s",
+			     messageType, ts_good, err_msg);
 			//_exit(-1);
 			goto abort;
 		}


### PR DESCRIPTION
This actually changes two things:
  * Use \t instead of \n similarly to what other error log messages do
  * Use the correct msg variable (err_msg instead of msg which is used
    for something else)