### PR TITLE
Added launchtime flag to talker

### DIFF
--- a/lib/avtp_pipeline/tl/openavb_talker.c
+++ b/lib/avtp_pipeline/tl/openavb_talker.c
@@ -127,7 +127,7 @@ bool talkerStartStream(tl_state_t *pTLState)
 	// setup the initial times
 	U64 nowNS;
 
-	if (!pCfg->spin_wait) {
+	if (!pCfg->spin_wait && !pCfg->launchtime) {
 		CLOCK_GETTIME64(OPENAVB_TIMER_CLOCK, &nowNS);
 	} else {
 		CLOCK_GETTIME64(OPENAVB_CLOCK_WALLTIME, &nowNS);
@@ -234,13 +234,11 @@ static inline bool talkerDoStream(tl_state_t *pTLState)
 
 		if (!pCfg->tx_blocking_in_intf) {
 
-			if (!pCfg->spin_wait) {
+			if (!pCfg->spin_wait && !pCfg->launchtime) {
 				// sleep until the next interval
 				SLEEP_UNTIL_NSEC(pTalkerData->nextCycleNS);
-			} else {
-#if !IGB_LAUNCHTIME_ENABLED && !ATL_LAUNCHTIME_ENABLED
+			} else if (pCfg->spin_wait) {
 				SPIN_UNTIL_NSEC(pTalkerData->nextCycleNS);
-#endif
 			}
 
 			//AVB_DBG_INTERVAL(8000, TRUE);
@@ -260,7 +258,7 @@ static inline bool talkerDoStream(tl_state_t *pTLState)
 				pTalkerData->cntFrames++;
 		}
 
-		if (!pCfg->spin_wait) {
+		if (!pCfg->spin_wait && !pCfg->launchtime) {
 			CLOCK_GETTIME64(OPENAVB_TIMER_CLOCK, &nowNS);
 		} else {
 			CLOCK_GETTIME64(OPENAVB_CLOCK_WALLTIME, &nowNS);

--- a/lib/avtp_pipeline/tl/openavb_tl.c
+++ b/lib/avtp_pipeline/tl/openavb_tl.c
@@ -394,6 +394,7 @@ EXTERN_DLL_EXPORT void openavbTLInitCfg(openavb_tl_cfg_t *pCfg)
 	pCfg->vlan_id = 0;
 	pCfg->fixed_timestamp = 0;
 	pCfg->spin_wait = FALSE;
+	pCfg->launchtime = IGB_LAUNCHTIME_ENABLED || ATL_LAUNCHTIME_ENABLED;
 	pCfg->thread_rt_priority = 0;
 	pCfg->thread_affinity = 0xFFFFFFFF;
 

--- a/lib/avtp_pipeline/tl/openavb_tl_pub.h
+++ b/lib/avtp_pipeline/tl/openavb_tl_pub.h
@@ -150,6 +150,8 @@ typedef struct {
 	U32 fixed_timestamp;
 	/// Wait for next observation interval by spinning rather than sleeping
 	bool spin_wait;
+	/// Do now wait for next observation interval, use launchtime feature
+	bool launchtime;
 	/// Bit mask used for CPU pinning
 	U32 thread_affinity;
 	/// Real time priority of thread.


### PR DESCRIPTION
Sometime ago spin wait was made separate from fixed_timestamp, this caused regression in builds using IGB_LAUNCHTIME_ENABLED=1.

This PR adds *launchtime* flag to talker which will be set automatically if IGB/ATL_LAUNCHTIME_ENABLED is used.

Otherwise we would need to use spin_wait flag to make launchtime work which would be counter-intuitive.

Both spin_wait and launchtime mode work on WALLCLOCK, but launchtime doesn't need any waiting because it will be done in ethernet driver.

So, we will have 3 modes for packet scheduling:
- sleep
- spin_wait
- launchtime

