### PR TITLE
Configuration options can be changed at runtime

### DIFF
--- a/lib/avtp_pipeline/platform/Linux/avb_host/CMakeLists.txt
+++ b/lib/avtp_pipeline/platform/Linux/avb_host/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries( openavb_host
 	avbTl
 	${PLATFORM_LINK_LIBRARIES}
 	${ALSA_LIBRARIES}
-	${GLIB_PKG_LIBRARIES}
 	pthread 
 	rt 
 	dl )
@@ -58,7 +57,6 @@ target_link_libraries( openavb_harness
 	avbTl
 	${PLATFORM_LINK_LIBRARIES}
 	${ALSA_LIBRARIES}
-	${GLIB_PKG_LIBRARIES}
 	pthread 
 	rt 
 	dl )

--- a/lib/avtp_pipeline/platform/Linux/avb_host/openavb_harness.c
+++ b/lib/avtp_pipeline/platform/Linux/avb_host/openavb_harness.c
@@ -157,6 +157,14 @@ void openavbTlHarnessMenu()
 		);
 }
 
+// manually matches following regular expression:
+//
+//     /(\d+)\s+([^\s]+)\s+(.*)\s*/
+//
+// where:
+//   $1 - idx
+//   $2 - name
+//   $3 - value
 int parse_idx_name_value(char* line, int* pIdx, char** pName, char** pValue)
 {
 	char *token = NULL;

--- a/lib/avtp_pipeline/platform/Linux/avb_host/openavb_harness.c
+++ b/lib/avtp_pipeline/platform/Linux/avb_host/openavb_harness.c
@@ -150,6 +150,7 @@ void openavbTlHarnessMenu()
 		" t            Stop all streams\n"
 		" l            List streams\n"
 		" 0-99         Toggle the state of the numbered stream\n"
+		" c N NAME VAL Change config option for stream N\n"
 		" m            Display this menu\n"
 		" z            Stats\n"
 		" x            Exit\n"
@@ -402,7 +403,7 @@ int main(int argc, char *argv[])
 
 		openavbTlHarnessMenu();
 		while (bRunning) {
-			char buf[16];
+			char buf[512];
 			printf("> ");
 			if (fgets(buf, sizeof(buf), stdin) == NULL) {
 				openavbTlHarnessMenu();
@@ -448,10 +449,25 @@ int main(int argc, char *argv[])
 						}
 					}
 					break;
+				case 'c':
+					{
+						int i1;
+						char name[512];
+						char value[512];
+						if (sscanf(&buf[1], "%d %s %s", &i1, name, value) == 3 && i1 < tlCount) {
+							openavb_tl_cfg_name_value_t NVCfg = {{name}, {value}, 1};
+							openavbTlChangeConfig(tlHandleList[i1], &NVCfg);
+						} else {
+							openavbTlHarnessMenu();
+						}
+
+					}
+					break;
 				case 'm':
 					// Display menu
 					openavbTlHarnessMenu();
 					break;
+
 				case 'z':
 					// Stats
 					{

--- a/lib/avtp_pipeline/platform/Linux/avb_host/openavb_harness.c
+++ b/lib/avtp_pipeline/platform/Linux/avb_host/openavb_harness.c
@@ -157,6 +157,31 @@ void openavbTlHarnessMenu()
 		);
 }
 
+int parse_idx_name_value(char* line, int* pIdx, char** pName, char** pValue)
+{
+	char *token = NULL;
+
+	int tmp = strtol(line, &token, 10);
+	if (token == line) return 0;
+	*pIdx = tmp;
+
+	while (isspace(*token)) ++token;
+	if (*token == '\0') return 1;
+
+	*pName = token;
+	while (!isspace(*++token) && *token != '\0') ;
+	if (*token == '\0') return 2;
+	*token = '\0';
+
+	while (isspace(*++token)) ;
+	if (*token == '\0') return 2;
+	*pValue = token;
+
+	token += strlen(token);
+	while (isspace(*--token) && *token != '\0') *token = '\0';
+
+	return 3;
+}
 
 /**********************************************
  * main
@@ -451,10 +476,11 @@ int main(int argc, char *argv[])
 					break;
 				case 'c':
 					{
-						int i1;
-						char name[512];
-						char value[512];
-						if (sscanf(&buf[1], "%d %s %s", &i1, name, value) == 3 && i1 < tlCount) {
+						int i1 = -1;
+						char *name = NULL;
+						char *value = NULL;
+
+						if (parse_idx_name_value(&buf[1], &i1, &name, &value) == 3 && i1 < tlCount) {
 							openavb_tl_cfg_name_value_t NVCfg = {{name}, {value}, 1};
 							openavbTlChangeConfig(tlHandleList[i1], &NVCfg);
 						} else {

--- a/lib/avtp_pipeline/tl/openavb_tl_pub.h
+++ b/lib/avtp_pipeline/tl/openavb_tl_pub.h
@@ -240,7 +240,17 @@ tl_handle_t openavbTLOpen(void);
 void openavbTLInitCfg(openavb_tl_cfg_t *pCfg);
 
 
-void openavbTlChangeConfig(tl_handle_t handle, openavb_tl_cfg_name_value_t *pNVCfg);
+/** Change talker's / listener's configuration item
+ *
+ * Changes one configuration option of talker / listener from name value pair.
+ * Only intf_nv_ and map_nv_ names are supported.
+ * Can be called while stream is running, assuming that map and intf modules
+ * are prepared for runtime changes of particular configration item.
+ *
+ * @param handle Handle of talker/listener
+ * @param pNVCfg Pointer to name value pair configuration structure
+ */
+void openavbTlChangeConfig(tl_handle_t handle, openavb_tl_cfg_name_value_t* pNVCfg);
 
 /** Configure the talker / listener.
  *

--- a/lib/avtp_pipeline/tl/openavb_tl_pub.h
+++ b/lib/avtp_pipeline/tl/openavb_tl_pub.h
@@ -239,6 +239,9 @@ tl_handle_t openavbTLOpen(void);
  */
 void openavbTLInitCfg(openavb_tl_cfg_t *pCfg);
 
+
+void openavbTlChangeConfig(tl_handle_t handle, openavb_tl_cfg_name_value_t *pNVCfg);
+
 /** Configure the talker / listener.
  *
  * Configures talker/listener with configuration values from configuration


### PR DESCRIPTION
This will allow creating GUI for openavb_harness. 

Example use cases.

To change volume at runtime enter in openavb_harness:

    c0 intf_nv_volume -20

To change filename of played wav file:

    c1 intf_nv_file_name test2.wav

c0, c1 means stream 0, stream 1 respectively.

Of course, it is not particularly handy to enter whose commands manually, but you can write the GUI wrapper which runs the openavb_harness and then issues those commands in response to user actions. 
