### PR TITLE
Map AAF uses userspecific format for little endian

### DIFF
--- a/lib/avtp_pipeline/map_aaf_audio/openavb_map_aaf_audio.c
+++ b/lib/avtp_pipeline/map_aaf_audio/openavb_map_aaf_audio.c
@@ -265,6 +265,12 @@ static void x_calculateSizes(media_q_t *pMediaQ)
 					break;
 			}
 		}
+
+		// If little endian byte order is requested switch to user specific format
+		if (pPubMapInfo->audioEndian == AVB_AUDIO_ENDIAN_LITTLE) {
+			pPvtData->aaf_format = AAF_FORMAT_UNSPEC;
+		}
+
 		AVB_LOGF_INFO("aaf_format=%d (%s%d)",
 			pPvtData->aaf_format, typeStr, pPubMapInfo->audioBitDepth);
 


### PR DESCRIPTION
OpenAvnu is great test tool for other AVB stacks. Sometimes on MCUs we have to use non-standard AAF format for performance reasons. Like when little-endian MCU have to handle 32 channels of 32 bit class A low latency audio. Byte swapping in software is just too much.

This fix will allow talkers to use little-endian settings.