### PR TITLE
Be compatible with dynamic stack size

### DIFF
--- a/daemons/maap/linux/src/maap_log_linux.c
+++ b/daemons/maap/linux/src/maap_log_linux.c
@@ -77,6 +77,8 @@ THREAD_DEFINITON(loggingThread);
 
 #if !defined(PTHREAD_STACK_MIN)
 #error "PTHREAD_STACK_MIN variable not defined"
+#elif defined(_DYNAMIC_STACK_SIZE_SOURCE) || defined(_GNU_SOURCE)
+#define THREAD_STACK_SIZE             ((PTHREAD_STACK_MIN) > 65536 ? (PTHREAD_STACK_MIN) : 65536 )
 #elif (PTHREAD_STACK_MIN > 65536)
 #define THREAD_STACK_SIZE							PTHREAD_STACK_MIN
 #else

--- a/daemons/shaper/src/shaper_log_linux.c
+++ b/daemons/shaper/src/shaper_log_linux.c
@@ -77,6 +77,8 @@ THREAD_DEFINITON(loggingThread);
 
 #if !defined(PTHREAD_STACK_MIN)
 #error "PTHREAD_STACK_MIN variable not defined"
+#elif defined(_DYNAMIC_STACK_SIZE_SOURCE) || defined(_GNU_SOURCE)
+#define THREAD_STACK_SIZE             ((PTHREAD_STACK_MIN) > 65536 ? (PTHREAD_STACK_MIN) : 65536 )
 #elif (PTHREAD_STACK_MIN > 65536)
 #define THREAD_STACK_SIZE							PTHREAD_STACK_MIN
 #else

--- a/lib/avtp_pipeline/platform/Linux/openavb_tasks.h
+++ b/lib/avtp_pipeline/platform/Linux/openavb_tasks.h
@@ -36,6 +36,8 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 
 #if !defined(PTHREAD_STACK_MIN)
 #error "PTHREAD_STACK_MIN variable not defined"
+#elif defined(_DYNAMIC_STACK_SIZE_SOURCE) || defined(_GNU_SOURCE)
+#define THREAD_STACK_SIZE             ((PTHREAD_STACK_MIN) > 65536 ? (PTHREAD_STACK_MIN) : 65536 )
 #elif (PTHREAD_STACK_MIN > 65536)
 #define THREAD_STACK_SIZE							PTHREAD_STACK_MIN
 #else


### PR DESCRIPTION
Since [Glibc 2.34](https://lists.gnu.org/archive/html/info-gnu/2021-08/msg00001.html) PTHREAD_STACK_MIN isn't a constant anymore. This checks if _DYNAMIC_STACK_SIZE_SOURCE is defined and determines THREAD_STACK_SIZE in run-time.